### PR TITLE
Catch assertion failures in stdlib coverage

### DIFF
--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -2154,6 +2154,51 @@ a 1, {2, b { 4 }} { 3 }
       (integer))))
 
 ================================================================================
+curly brace after a range operator
+================================================================================
+puts 1, 2 .. { 3 }
+puts 4, {a: 5} ... { b: 6 }
+puts 1, 2.. { 3 => 4 }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (call
+    method: (identifier)
+    arguments: (argument_list
+      (integer)
+      (range
+        begin: (integer)
+        operator: (operator)
+        end: (tuple
+          (integer)))))
+  (call
+    method: (identifier)
+    arguments: (argument_list
+      (integer)
+      (range
+        begin: (named_tuple
+          (named_expr
+            name: (identifier)
+            (integer)))
+        operator: (operator)
+        end: (named_tuple
+          (named_expr
+            name: (identifier)
+            (integer))))))
+  (call
+    method: (identifier)
+    arguments: (argument_list
+      (integer)
+      (range
+        begin: (integer)
+        operator: (operator)
+        end: (hash
+          (hash_entry
+            (integer)
+            (integer)))))))
+
+================================================================================
 calls with & block forwarding
 ================================================================================
 foo(&block)

--- a/test/stdlib_coverage.cr
+++ b/test/stdlib_coverage.cr
@@ -69,7 +69,7 @@ stdlib_files.each do |stdlib_file|
   else
     failed << test.label
   end
-  elapsed_ms = "#{test.elapsed.total_milliseconds}ms".colorize.dark_gray
+  elapsed_ms = sprintf("%8.3fms", test.elapsed.total_milliseconds).colorize.dark_gray
   # Why 63? So we match 80 columns.
   printf("%-63s %s %s\n", test.label, success ? PASS : FAIL, elapsed_ms)
 end


### PR DESCRIPTION
If the stdlib coverage test triggers an assertion failure, segfault, or other unusual exit code, the whole test run is aborted.

Also, fix an assertion failure I found.
