### PR TITLE
Allow instance vars to be the method of a call

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1493,6 +1493,7 @@ module.exports = grammar({
         $.identifier,
         alias($.identifier_method_call, $.identifier),
         alias($._operator_token, $.operator),
+        $.instance_var,
       ))
 
       // In the case of something like

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6398,6 +6398,10 @@
                       },
                       "named": true,
                       "value": "operator"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "instance_var"
                     }
                   ]
                 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3240,6 +3240,10 @@
             "named": true
           },
           {
+            "type": "instance_var",
+            "named": true
+          },
+          {
             "type": "operator",
             "named": true
           }

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -3308,3 +3308,16 @@ end
           var: (identifier)
           type: (constant)
           value: (string))))))
+
+=================
+read instance var
+=================
+
+object.@ivar
+
+---
+
+(source_file
+  (call
+    receiver: (identifier)
+    method: (instance_var)))

--- a/test/corpus/todo.txt
+++ b/test/corpus/todo.txt
@@ -284,22 +284,6 @@ uninitialized Class
     (argument_list
       (constant))))
 
-====
-read instance var
-====
-
-object.@ivar
-
----
-
-(source_file
-  (call
-    (identifier)
-    (MISSING identifier)
-    (argument_list
-      (instance_var))))
-
-
 ======
 asm
 :error

--- a/test/stdlib_coverage_expected_to_fail.txt
+++ b/test/stdlib_coverage_expected_to_fail.txt
@@ -2,7 +2,6 @@ array.cr
 atomic.cr
 base64.cr
 benchmark.cr
-big/big_decimal.cr
 big/big_int.cr
 big/lib_gmp.cr
 big/number.cr
@@ -38,7 +37,6 @@ compiler/crystal/interpreter/disassembler.cr
 compiler/crystal/interpreter/escaping_exception.cr
 compiler/crystal/interpreter/instructions.cr
 compiler/crystal/interpreter/interpreter.cr
-compiler/crystal/interpreter/local_vars.cr
 compiler/crystal/interpreter/op_code.cr
 compiler/crystal/interpreter/primitives.cr
 compiler/crystal/interpreter/pry_reader.cr
@@ -976,10 +974,8 @@ regex.cr
 regex/engine.cr
 regex/lib_pcre.cr
 regex/lib_pcre2.cr
-regex/match_data.cr
 regex/pcre.cr
 regex/pcre2.cr
-set.cr
 signal.cr
 slice.cr
 socket/address.cr
@@ -997,7 +993,6 @@ static_array.cr
 string.cr
 string/builder.cr
 string/formatter.cr
-string/grapheme/grapheme.cr
 struct.cr
 syscall.cr
 syscall/aarch64-linux.cr


### PR DESCRIPTION
Closes #7 

In the stdlib, this is a node called ReadInstanceVar - I don't think that needs to be done here though.

5 more stdlib files parse without errors