### PR TITLE
Set token precedence for char rule

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -102,8 +102,6 @@ module.exports = grammar({
     $._delimited_string_contents,
     $._string_literal_end,
 
-    $._char_comment,
-
     $._string_percent_literal_start,
     $._command_percent_literal_start,
     $._string_array_percent_literal_start,
@@ -562,9 +560,8 @@ module.exports = grammar({
     char: $ => seq(
       '\'',
       choice(
-        token.immediate(/[^\\]/),
+        token.immediate(prec(1, /[^\\]/)),
         $.char_escape_sequence,
-        $._char_comment
       ),
       token.immediate('\''),
     ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1883,17 +1883,17 @@
             {
               "type": "IMMEDIATE_TOKEN",
               "content": {
-                "type": "PATTERN",
-                "value": "[^\\\\]"
+                "type": "PREC",
+                "value": 1,
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\\\]"
+                }
               }
             },
             {
               "type": "SYMBOL",
               "name": "char_escape_sequence"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_char_comment"
             }
           ]
         },
@@ -11336,10 +11336,6 @@
     {
       "type": "SYMBOL",
       "name": "_string_literal_end"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "_char_comment"
     },
     {
       "type": "SYMBOL",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -72,8 +72,6 @@ enum Token {
     DELIMITED_STRING_CONTENTS,
     STRING_LITERAL_END,
 
-    CHAR_COMMENT,
-
     STRING_PERCENT_LITERAL_START,
     COMMAND_PERCENT_LITERAL_START,
     STRING_ARRAY_PERCENT_LITERAL_START,
@@ -1110,12 +1108,6 @@ static bool inner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols)
         return true;
     }
 
-    if (valid_symbols[CHAR_COMMENT] && lexer->lookahead == '#') {
-        lex_advance(lexer);
-        lexer->result_symbol = CHAR_COMMENT;
-        return true;
-    }
-
     switch (lexer->lookahead) {
         case '{':
 
@@ -2094,7 +2086,6 @@ bool tree_sitter_crystal_external_scanner_scan(void *payload, TSLexer *lexer, co
     LOG_SYMBOL(STRING_LITERAL_START);
     LOG_SYMBOL(DELIMITED_STRING_CONTENTS);
     LOG_SYMBOL(STRING_LITERAL_END);
-    LOG_SYMBOL(CHAR_COMMENT);
     LOG_SYMBOL(STRING_PERCENT_LITERAL_START);
     LOG_SYMBOL(COMMAND_PERCENT_LITERAL_START);
     LOG_SYMBOL(STRING_ARRAY_PERCENT_LITERAL_START);


### PR DESCRIPTION
https://github.com/crystal-lang-tools/tree-sitter-crystal/pull/12 solved the problem of `'#'` being parsed as a comment, but I want to suggest a different way to handle this.

I believe this is a [token conflict](https://tree-sitter.github.io/tree-sitter/creating-parsers#conflicting-tokens). The `comment` rule is in `extras`, so it can match almost anywhere. And `comment` took precedence because the regex it's using, `/#.*/`, generates a longer match than `/[^\\]/`.

Using `_char_comment` in the external scanner only overrides the precedence for `#`. Using `prec(1, ...)` will also handle any future token conflicts if new rules get added to `extras`.