### PR TITLE
Add more to `todo.txt` and fix some parsing errors

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -473,6 +473,7 @@ module.exports = grammar({
 
       // Methods
       $.call,
+      alias($.global_call, $.call),
 
       alias($.additive_operator, $.op_call),
       alias($.unary_additive_operator, $.op_call),
@@ -1775,6 +1776,30 @@ module.exports = grammar({
 
         prec('ampersand_block_call', seq(receiver_call, argument_list_with_block)),
         prec('ampersand_block_call', seq(ambiguous_call, argument_list_with_block)),
+      )
+    },
+
+    global_call: $ => {
+      const ambiguous_call = field('method', $.identifier)
+
+      const argument_list = field('arguments', choice(
+        alias($.argument_list_with_parens, $.argument_list),
+        alias($.argument_list_no_parens, $.argument_list),
+      ))
+
+      const argument_list_with_block = field('arguments', choice(
+        alias($.argument_list_with_parens_and_block, $.argument_list),
+        alias($.argument_list_no_parens_with_block, $.argument_list),
+      ))
+
+      const brace_block = field('block', alias($.brace_block, $.block))
+      const do_end_block = field('block', alias($.do_end_block, $.block))
+
+      return choice(
+        prec('no_block_call', seq('::', ambiguous_call, argument_list)),
+        prec('brace_block_call', seq('::', ambiguous_call, optional(argument_list), brace_block)),
+        prec('do_end_block_call', seq('::', ambiguous_call, optional(argument_list), do_end_block)),
+        prec('ampersand_block_call', seq('::', ambiguous_call, argument_list_with_block)),
       )
     },
 

--- a/grammar.js
+++ b/grammar.js
@@ -2413,7 +2413,7 @@ module.exports = grammar({
 
       return seq(
         'case',
-        cond,
+        optional(cond),
         repeat($.when),
         optional($.else),
         'end',

--- a/grammar.js
+++ b/grammar.js
@@ -1362,7 +1362,17 @@ module.exports = grammar({
       )
     },
 
-    return: $ => seq('return', optional($._expression)),
+    return: $ => {
+      const expressions = choice(
+        $._expression,
+        seq(
+          $._expression,
+          repeat(seq(',', $._expression)),
+        ),
+      )
+
+      return seq('return', optional(expressions))
+    },
 
     next: $ => seq('next', optional($._expression)),
 

--- a/grammar.js
+++ b/grammar.js
@@ -1022,6 +1022,7 @@ module.exports = grammar({
     ),
 
     enum_def: $ => seq(
+      optional('private'),
       'enum',
       field('name', alias($._constant_segment, $.constant)),
       optional(field('type', seq(/:\s/, $._bare_type))),

--- a/grammar.js
+++ b/grammar.js
@@ -714,7 +714,7 @@ module.exports = grammar({
         seq(
           choice(ident_start, const_start),
           repeat(ident_part),
-          optional(/[?!]/),
+          optional(/[?!=]/),
         ),
       ),
     )),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4155,6 +4155,18 @@
       "type": "SEQ",
       "members": [
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "private"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "STRING",
           "value": "enum"
         },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -594,15 +594,6 @@
           "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
-            "name": "global_call"
-          },
-          "named": true,
-          "value": "call"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
             "name": "additive_operator"
           },
           "named": true,
@@ -5979,23 +5970,22 @@
         }
       ]
     },
-    "return": {
-      "type": "SEQ",
+    "_control_expressions": {
+      "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "return"
-        },
-        {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
+            {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "STRING",
+                "value": "("
+              }
+            },
             {
               "type": "CHOICE",
               "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_expression"
-                },
                 {
                   "type": "SEQ",
                   "members": [
@@ -6020,8 +6010,70 @@
                       }
                     }
                   ]
+                },
+                {
+                  "type": "BLANK"
                 }
               ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expression"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "return": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "return"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_control_expressions"
             },
             {
               "type": "BLANK"
@@ -6042,7 +6094,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_expression"
+              "name": "_control_expressions"
             },
             {
               "type": "BLANK"
@@ -6063,7 +6115,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_expression"
+              "name": "_control_expressions"
             },
             {
               "type": "BLANK"
@@ -7568,6 +7620,10 @@
                       "named": true,
                       "value": "identifier"
                     }
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_global_method"
                   }
                 ]
               },
@@ -7678,6 +7734,10 @@
                       "named": true,
                       "value": "identifier"
                     }
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_global_method"
                   }
                 ]
               },
@@ -7822,6 +7882,10 @@
                       "named": true,
                       "value": "identifier"
                     }
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_global_method"
                   }
                 ]
               },
@@ -7966,6 +8030,10 @@
                       "named": true,
                       "value": "identifier"
                     }
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_global_method"
                   }
                 ]
               },
@@ -8045,239 +8113,31 @@
         }
       ]
     },
-    "global_call": {
-      "type": "CHOICE",
+    "_global_method": {
+      "type": "SEQ",
       "members": [
         {
-          "type": "PREC",
-          "value": "no_block_call",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "::"
-              },
-              {
-                "type": "FIELD",
-                "name": "method",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "arguments",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "argument_list_with_parens"
-                      },
-                      "named": true,
-                      "value": "argument_list"
-                    },
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "argument_list_no_parens"
-                      },
-                      "named": true,
-                      "value": "argument_list"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
+          "type": "STRING",
+          "value": "::"
         },
         {
-          "type": "PREC",
-          "value": "brace_block_call",
+          "type": "FIELD",
+          "name": "method",
           "content": {
-            "type": "SEQ",
+            "type": "CHOICE",
             "members": [
               {
-                "type": "STRING",
-                "value": "::"
+                "type": "SYMBOL",
+                "name": "identifier"
               },
               {
-                "type": "FIELD",
-                "name": "method",
+                "type": "ALIAS",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "identifier"
-                }
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "FIELD",
-                    "name": "arguments",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "ALIAS",
-                          "content": {
-                            "type": "SYMBOL",
-                            "name": "argument_list_with_parens"
-                          },
-                          "named": true,
-                          "value": "argument_list"
-                        },
-                        {
-                          "type": "ALIAS",
-                          "content": {
-                            "type": "SYMBOL",
-                            "name": "argument_list_no_parens"
-                          },
-                          "named": true,
-                          "value": "argument_list"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "FIELD",
-                "name": "block",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "brace_block"
-                  },
-                  "named": true,
-                  "value": "block"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC",
-          "value": "do_end_block_call",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "::"
-              },
-              {
-                "type": "FIELD",
-                "name": "method",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                }
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "FIELD",
-                    "name": "arguments",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "ALIAS",
-                          "content": {
-                            "type": "SYMBOL",
-                            "name": "argument_list_with_parens"
-                          },
-                          "named": true,
-                          "value": "argument_list"
-                        },
-                        {
-                          "type": "ALIAS",
-                          "content": {
-                            "type": "SYMBOL",
-                            "name": "argument_list_no_parens"
-                          },
-                          "named": true,
-                          "value": "argument_list"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "FIELD",
-                "name": "block",
-                "content": {
-                  "type": "ALIAS",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "do_end_block"
-                  },
-                  "named": true,
-                  "value": "block"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC",
-          "value": "ampersand_block_call",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "::"
-              },
-              {
-                "type": "FIELD",
-                "name": "method",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                }
-              },
-              {
-                "type": "FIELD",
-                "name": "arguments",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "argument_list_with_parens_and_block"
-                      },
-                      "named": true,
-                      "value": "argument_list"
-                    },
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "argument_list_no_parens_with_block"
-                      },
-                      "named": true,
-                      "value": "argument_list"
-                    }
-                  ]
-                }
+                  "name": "identifier_method_call"
+                },
+                "named": true,
+                "value": "identifier"
               }
             ]
           }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2667,7 +2667,7 @@
                   "members": [
                     {
                       "type": "PATTERN",
-                      "value": "[?!]"
+                      "value": "[?!=]"
                     },
                     {
                       "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5990,8 +5990,38 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_expression"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_expression"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_expression"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "_expression"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
             },
             {
               "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -11662,12 +11662,20 @@
           "value": "case"
         },
         {
-          "type": "FIELD",
-          "name": "cond",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_expression"
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "cond",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_expression"
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "REPEAT",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -594,6 +594,15 @@
           "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
+            "name": "global_call"
+          },
+          "named": true,
+          "value": "call"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
             "name": "additive_operator"
           },
           "named": true,
@@ -7966,6 +7975,245 @@
           "content": {
             "type": "SEQ",
             "members": [
+              {
+                "type": "FIELD",
+                "name": "method",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "arguments",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "argument_list_with_parens_and_block"
+                      },
+                      "named": true,
+                      "value": "argument_list"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "argument_list_no_parens_with_block"
+                      },
+                      "named": true,
+                      "value": "argument_list"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "global_call": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC",
+          "value": "no_block_call",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "::"
+              },
+              {
+                "type": "FIELD",
+                "name": "method",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "arguments",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "argument_list_with_parens"
+                      },
+                      "named": true,
+                      "value": "argument_list"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "argument_list_no_parens"
+                      },
+                      "named": true,
+                      "value": "argument_list"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC",
+          "value": "brace_block_call",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "::"
+              },
+              {
+                "type": "FIELD",
+                "name": "method",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "arguments",
+                    "content": {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "argument_list_with_parens"
+                          },
+                          "named": true,
+                          "value": "argument_list"
+                        },
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "argument_list_no_parens"
+                          },
+                          "named": true,
+                          "value": "argument_list"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "FIELD",
+                "name": "block",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "brace_block"
+                  },
+                  "named": true,
+                  "value": "block"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC",
+          "value": "do_end_block_call",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "::"
+              },
+              {
+                "type": "FIELD",
+                "name": "method",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "arguments",
+                    "content": {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "argument_list_with_parens"
+                          },
+                          "named": true,
+                          "value": "argument_list"
+                        },
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "argument_list_no_parens"
+                          },
+                          "named": true,
+                          "value": "argument_list"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "FIELD",
+                "name": "block",
+                "content": {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "do_end_block"
+                  },
+                  "named": true,
+                  "value": "block"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC",
+          "value": "ampersand_block_call",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "::"
+              },
               {
                 "type": "FIELD",
                 "name": "method",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -18374,7 +18374,7 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3761,7 +3761,7 @@
     "fields": {
       "cond": {
         "multiple": true,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "(",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2985,7 +2985,7 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
         {
@@ -14476,7 +14476,7 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
         {

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -3400,3 +3400,25 @@ global method calls
     (identifier)
     (argument_list
       (string))))
+
+=============================
+comma-separated return values
+=============================
+
+def hello(a, b)
+  return a, b
+end
+
+---
+
+(source_file
+  (method_def
+    (identifier)
+    (param_list
+      (param
+        (identifier))
+      (param
+        (identifier)))
+    (return
+      (identifier)
+      (identifier))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -3139,6 +3139,26 @@ end
           (proc_type
             return: (constant)))))))
 
+======================
+case without condition
+======================
+
+case
+when true
+  puts "world"
+end
+
+---
+
+(source_file
+  (case
+    (when
+      (true)
+      (call
+        (identifier)
+        (argument_list
+          (string))))))
+
 ================
 select statement
 ================

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -3386,3 +3386,17 @@ object.@ivar
   (call
     receiver: (identifier)
     method: (instance_var)))
+
+======================
+global method calls
+======================
+
+::raise "Error message"
+
+---
+
+(source_file
+  (call
+    (identifier)
+    (argument_list
+      (string))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -3401,12 +3401,40 @@ global method calls
     (argument_list
       (string))))
 
-=============================
-comma-separated return values
-=============================
+===============================================
+comma-separated and parenthesized return values
+===============================================
 
 def hello(a, b)
   return a, b
+  return \
+1,
+2
+  return {a, b}, [c, d]
+  return 1, 2, 3,
+         4, 5, 6,
+         7, 8, 9
+
+  return 1 +
+  2 ,
+  3 +
+  4 ,
+  method
+  .call(
+  a ,
+  b
+  )
+
+  return()
+  return(a, b)
+
+  return(
+    1, 2, 3,
+    4, 5, 6,
+  )
+
+  return
+  1, 2
 end
 
 ---
@@ -3421,4 +3449,53 @@ end
         (identifier)))
     (return
       (identifier)
-      (identifier))))
+      (identifier))
+    (return
+      (integer)
+      (integer))
+    (return
+      (tuple
+        (identifier)
+        (identifier))
+      (array
+        (identifier)
+        (identifier)))
+    (return
+      (integer)
+      (integer)
+      (integer)
+      (integer)
+      (integer)
+      (integer)
+      (integer)
+      (integer)
+      (integer))
+    (return
+      (op_call
+        (integer)
+        (operator)
+        (integer))
+      (op_call
+        (integer)
+        (operator)
+        (integer))
+      (call
+        (identifier)
+        (identifier)
+        (argument_list
+          (identifier)
+          (identifier))))
+    (return)
+    (return
+      (identifier)
+      (identifier))
+    (return
+      (integer)
+      (integer)
+      (integer)
+      (integer)
+      (integer)
+      (integer))
+    (return)
+    (integer)
+    (ERROR)))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -854,6 +854,27 @@ end
       name: (identifier)
       (string))))
 
+=============
+private enums
+=============
+
+module MyModule
+  private enum MyEnum
+    Member1
+    Member2
+  end
+end
+
+---
+
+(source_file
+  (module_def
+    (constant)
+    (enum_def
+      (constant)
+      (constant)
+      (constant))))
+
 ================================================================================
 line continuations
 ================================================================================

--- a/test/corpus/todo.txt
+++ b/test/corpus/todo.txt
@@ -323,6 +323,111 @@ end
       arguments: (argument_list
         (string)))))
 
+=================================
+private and protected macro calls
+=================================
+
+class Foo
+  private getter foo
+  protected property bar : Baz
+end
+
+---
+
+(source_file
+  (class_def
+    (constant)
+    (ERROR)
+    (call
+      (identifier)
+      (argument_list
+        (identifier)))
+    (ERROR)
+    (call
+      (identifier)
+      (argument_list
+        (type_declaration
+          (identifier)
+          (constant))))))
+
+=======================
+assign special variable
+=======================
+
+$~ = $~
+
+---
+
+(source_file
+  (ERROR
+    (special_variable))
+  (special_variable))
+
+============================
+.as method with pointer type
+============================
+
+node.as(LibXML::Node*)
+
+---
+
+(source_file
+  (call
+    (identifier)
+    (identifier)
+    (argument_list
+      (op_call
+        (constant)
+        (operator)
+        (MISSING identifier)))))
+
+==============================
+instance var with pointer type
+==============================
+
+@ivar : UInt8*
+
+---
+
+(source_file
+  (op_call
+    (type_declaration
+      (instance_var)
+      (constant))
+    (operator)
+    (MISSING identifier)))
+
+=================================
+Array-like and hash-like literals
+:error
+=================================
+
+Set{1, 2, 3}
+MyType{"foo" => "bar"}
+
+---
+
+===================================
+chained calls in short block syntax
+:error
+===================================
+
+reject! &.field.option
+find(&.name.==(name))
+
+---
+
+
+=================
+static array type
+:error
+=================
+
+StaticArray(Int32, 8)
+StaticArray(Char*, 2)
+
+---
+
 ==========================
 symbols ending with equals
 ==========================
@@ -342,3 +447,17 @@ symbols ending with equals
     (symbol)
     (operator)
     (identifier)))
+
+=================================
+case expression with typed tuples
+:error
+=================================
+
+case {value, this_value}
+in {String, String}
+	puts "hello"
+in {Int32, false}
+	puts "world"
+end
+
+---

--- a/test/corpus/todo.txt
+++ b/test/corpus/todo.txt
@@ -322,3 +322,23 @@ end
       method: (identifier)
       arguments: (argument_list
         (string)))))
+
+==========================
+symbols ending with equals
+==========================
+
+:hello=
+:world==world
+:world == world
+
+---
+
+(source_file
+  (symbol)
+  (symbol)
+  (ERROR
+    (identifier))
+  (op_call
+    (symbol)
+    (operator)
+    (identifier)))

--- a/test/stdlib_coverage.cr
+++ b/test/stdlib_coverage.cr
@@ -77,9 +77,12 @@ stdlib_files.each do |stdlib_file|
   else
     failed << test.label
   end
+
+  `grep -q -e '{{' -e '{%' -e '\bmacro\b' '#{stdlib_file}'`
+
   elapsed_ms = sprintf("%8.3fms", test.elapsed.total_milliseconds).colorize.dark_gray
   # Why 63? So we match 80 columns.
-  printf("%-63s %s %s\n", test.label, success ? PASS : FAIL, elapsed_ms)
+  printf("%-63s %s %s %s\n", test.label, success ? PASS : FAIL, $?.success? ? "macro" : "     ", elapsed_ms)
 end
 
 pass_str = (100 * (pass / stdlib_files.size)).format(decimal_places: 2) + "%"

--- a/test/stdlib_coverage_expected_to_fail.txt
+++ b/test/stdlib_coverage_expected_to_fail.txt
@@ -46,8 +46,6 @@ compiler/crystal/loader/unix.cr
 compiler/crystal/macros.cr
 compiler/crystal/macros/macros.cr
 compiler/crystal/macros/methods.cr
-compiler/crystal/semantic/ast.cr
-compiler/crystal/semantic/bindings.cr
 compiler/crystal/semantic/call.cr
 compiler/crystal/semantic/call_error.cr
 compiler/crystal/semantic/cleanup_transformer.cr
@@ -174,7 +172,6 @@ crystal/system/win32/zone_names.cr
 crystal/system/windows.cr
 crystal/tracing.cr
 csv.cr
-csv/lexer.cr
 csv/lexer/io_based.cr
 deque.cr
 digest/digest.cr
@@ -237,7 +234,6 @@ iterator.cr
 json/any.cr
 json/builder.cr
 json/from_json.cr
-json/lexer.cr
 json/lexer/io_based.cr
 json/parser.cr
 json/pull_parser.cr
@@ -509,7 +505,6 @@ syscall/i386-linux.cr
 syscall/x86_64-linux.cr
 termios.cr
 time.cr
-time/format/parser.cr
 time/location.cr
 tuple.cr
 unicode/data.cr
@@ -520,7 +515,6 @@ uri/params/serializable.cr
 uri/uri_parser.cr
 uuid.cr
 va_list.cr
-wait_group.cr
 weak_ref.cr
 winerror.cr
 xml.cr
@@ -532,7 +526,6 @@ yaml/any.cr
 yaml/builder.cr
 yaml/from_yaml.cr
 yaml/lib_yaml.cr
-yaml/nodes/nodes.cr
 yaml/pull_parser.cr
 yaml/schema/core.cr
 yaml/serialization.cr

--- a/test/stdlib_coverage_expected_to_fail.txt
+++ b/test/stdlib_coverage_expected_to_fail.txt
@@ -60,12 +60,10 @@ compiler/crystal/semantic/lib.cr
 compiler/crystal/semantic/literal_expander.cr
 compiler/crystal/semantic/main_visitor.cr
 compiler/crystal/semantic/restrictions.cr
-compiler/crystal/semantic/top_level_visitor.cr
 compiler/crystal/semantic/type_declaration_processor.cr
 compiler/crystal/semantic/type_guess_visitor.cr
 compiler/crystal/semantic/type_lookup.cr
 compiler/crystal/syntax/ast.cr
-compiler/crystal/syntax/to_s.cr
 compiler/crystal/syntax/token.cr
 compiler/crystal/tools/doc/markd_doc_renderer.cr
 compiler/crystal/tools/doc/method.cr
@@ -222,7 +220,6 @@ hash.cr
 html.cr
 http/client.cr
 http/common.cr
-http/formdata/builder.cr
 http/headers.cr
 http/server.cr
 http/server/handlers/compress_handler.cr
@@ -457,7 +454,6 @@ macros.cr
 math/libm.cr
 math/math.cr
 mime/media_type.cr
-mime/multipart/state.cr
 named_tuple.cr
 number.cr
 oauth2/client.cr

--- a/test/stdlib_coverage_expected_to_fail.txt
+++ b/test/stdlib_coverage_expected_to_fail.txt
@@ -25,7 +25,6 @@ compiler/crystal/codegen/primitives.cr
 compiler/crystal/command.cr
 compiler/crystal/command/repl.cr
 compiler/crystal/compiler.cr
-compiler/crystal/exception.cr
 compiler/crystal/ffi/ffi.cr
 compiler/crystal/ffi/lib_ffi.cr
 compiler/crystal/interpreter.cr
@@ -47,7 +46,6 @@ compiler/crystal/loader/unix.cr
 compiler/crystal/macros.cr
 compiler/crystal/macros/macros.cr
 compiler/crystal/macros/methods.cr
-compiler/crystal/semantic/abstract_def_checker.cr
 compiler/crystal/semantic/ast.cr
 compiler/crystal/semantic/bindings.cr
 compiler/crystal/semantic/call.cr
@@ -180,7 +178,6 @@ csv/lexer.cr
 csv/lexer/io_based.cr
 deque.cr
 digest/digest.cr
-dir/glob.cr
 docs_pseudo_methods.cr
 ecr/macros.cr
 empty.cr
@@ -217,7 +214,6 @@ gc.cr
 gc/boehm.cr
 gc/none.cr
 hash.cr
-html.cr
 http/client.cr
 http/common.cr
 http/headers.cr
@@ -235,7 +231,6 @@ io/console.cr
 io/encoding.cr
 io/encoding_stubs.cr
 io/evented.cr
-io/hexdump.cr
 io/memory.cr
 io/stapled.cr
 iterator.cr
@@ -414,7 +409,6 @@ lib_c/x86_64-windows-msvc/c/winnt.cr
 lib_c/x86_64-windows-msvc/c/ws2ipdef.cr
 lib_z/lib_z.cr
 llvm.cr
-llvm/abi/x86_64.cr
 llvm/basic_block_collection.cr
 llvm/builder.cr
 llvm/context.cr

--- a/test/stdlib_coverage_expected_to_fail.txt
+++ b/test/stdlib_coverage_expected_to_fail.txt
@@ -8,7 +8,6 @@ big/number.cr
 bit_array.cr
 box.cr
 channel.cr
-channel/select.cr
 char.cr
 class.cr
 colorize.cr
@@ -46,7 +45,6 @@ compiler/crystal/loader/unix.cr
 compiler/crystal/macros.cr
 compiler/crystal/macros/macros.cr
 compiler/crystal/macros/methods.cr
-compiler/crystal/semantic/call.cr
 compiler/crystal/semantic/call_error.cr
 compiler/crystal/semantic/cleanup_transformer.cr
 compiler/crystal/semantic/cover.cr
@@ -63,7 +61,6 @@ compiler/crystal/syntax/ast.cr
 compiler/crystal/syntax/token.cr
 compiler/crystal/tools/doc/markd_doc_renderer.cr
 compiler/crystal/tools/doc/method.cr
-compiler/crystal/tools/doc/project_info.cr
 compiler/crystal/tools/doc/type.cr
 compiler/crystal/tools/init.cr
 compiler/crystal/tools/playground.cr
@@ -201,9 +198,7 @@ fiber/context/x86_64-sysv.cr
 file.cr
 file/error.cr
 float.cr
-float/printer/cached_powers.cr
 float/printer/dragonbox.cr
-float/printer/grisu3.cr
 float/printer/hexfloat.cr
 float/printer/ryu_printf.cr
 float/printer/ryu_printf_table.cr
@@ -229,7 +224,6 @@ io/encoding.cr
 io/encoding_stubs.cr
 io/evented.cr
 io/memory.cr
-io/stapled.cr
 iterator.cr
 json/any.cr
 json/builder.cr
@@ -443,7 +437,6 @@ log/metadata.cr
 macros.cr
 math/libm.cr
 math/math.cr
-mime/media_type.cr
 named_tuple.cr
 number.cr
 oauth2/client.cr


### PR DESCRIPTION
Closes #30, #28

- Adds support for global calls (`::raise "message"`)
- Allow symbols to end with `=` (still more todo for this though)
- Allow comma-separated and parenthesized break / next / return values
- Make condition in case statement optional
- Enums can be private
- Print whether a stdlib file contains macros when doing coverage (useful for finding non-macro parsing errors)

24 more stdlib files can be parsed without errors.