### PR TITLE
endless heredocs don't consume rest of document

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -589,7 +589,7 @@ static bool scan_heredoc_contents(State *state, TSLexer *lexer, const bool *vali
         for (;;) {
             if (lexer->eof(lexer)) {
                 DEBUG("reached EOF");
-                return found_content;
+                return false;
             }
 
             switch (lexer->lookahead) {

--- a/test/corpus/errors.txt
+++ b/test/corpus/errors.txt
@@ -517,3 +517,26 @@ missing_quote
       (ERROR)
       (identifier)))
   (identifier))
+
+=================================================
+endless heredocs don't consume remaining document
+=================================================
+
+method.call <<-SQL, user_id
+
+puts "hello world"
+
+---
+
+(source_file
+  (call
+    receiver: (identifier)
+    method: (identifier)
+    arguments: (argument_list
+      (heredoc_start)
+      (identifier)))
+  (ERROR)
+  (call
+    method: (identifier)
+    arguments: (argument_list
+      (string))))

--- a/test/corpus/errors.txt
+++ b/test/corpus/errors.txt
@@ -522,9 +522,21 @@ missing_quote
 endless heredocs don't consume remaining document
 =================================================
 
-method.call <<-SQL, user_id
+method.call <<-SQL1, user_id
 
 puts "hello world"
+
+method.call <<-SQL2, <<-HTML1
+
+HTML1
+
+puts :"hello world"
+
+method.call <<-SQL3, <<-HTML2
+
+SQL3
+
+puts %w[hello world]
 
 ---
 
@@ -539,4 +551,32 @@ puts "hello world"
   (call
     method: (identifier)
     arguments: (argument_list
-      (string))))
+      (string)))
+  (call
+    receiver: (identifier)
+    method: (identifier)
+    arguments: (argument_list
+      (heredoc_start)
+      (ERROR
+        (heredoc_start))
+      (constant)))
+  (call
+    method: (identifier)
+    arguments: (argument_list
+      (symbol)))
+  (call
+    receiver: (identifier)
+    method: (identifier)
+    arguments: (argument_list
+      (heredoc_start)
+      (ERROR
+        (heredoc_start)
+        (heredoc_body
+          (heredoc_content)
+          (heredoc_end)))
+      (call
+        method: (identifier)
+        arguments: (argument_list
+          (array
+            (string)
+            (string)))))))


### PR DESCRIPTION
Closes #23 

This works on paper but not 100% as I'm not as familiar with the heredoc parsing here.

Also, this change could go either way, as it's debatable which is preferable. I think this way is better as when adding a new heredoc to the middle of a document, you don't have to deal with everything else in the document being turned into a string until you add the heredoc end. But if you're changing the heredoc name, you may end up with the contents inside parsed as Crystal.
