### PR TITLE
Move dot index calls to a separate rule

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -523,6 +523,7 @@ module.exports = grammar({
       alias($.equality_operator, $.op_call),
       alias($.comparison_operator, $.op_call),
       alias($.index_operator, $.index_call),
+      $.index_call,
       $.assign,
       alias($.operator_assign, $.op_assign),
 
@@ -1792,25 +1793,7 @@ module.exports = grammar({
         $.instance_var,
       ))
 
-      // In the case of something like
-      //   a.[*{0}]
-      // we need to parse the arguments here, because they're embedded in the
-      // method "name".
-      const bracket_method = seq(
-        field('method', alias('[', $.operator)),
-        alias($.bracket_argument_list, $.argument_list),
-        ']',
-        optional(choice(
-          token.immediate('?'),
-          '=',
-        )),
-      )
-
-      return prec('dot_operator', seq(
-        receiver,
-        '.',
-        choice(method, bracket_method),
-      ))
+      return prec('dot_operator', seq(receiver, '.', method))
     },
 
     bracket_argument_list: $ => {
@@ -2046,6 +2029,16 @@ module.exports = grammar({
       ))
     },
 
+    index_call: $ => {
+      return seq(
+        field('receiver', $._expression),
+        '.',
+        field('method', alias('[', $.operator)),
+        alias($.bracket_argument_list, $.argument_list),
+        choice(']', ']?'),
+      )
+    },
+
     not: $ => prec('unary_operator', seq('!', $._expression)),
     and: $ => prec.left('logical_and_operator', seq($._expression, '&&', $._expression)),
     or: $ => prec.left('logical_or_operator', seq($._expression, '||', $._expression)),
@@ -2258,6 +2251,7 @@ module.exports = grammar({
         $.instance_var,
         $.class_var,
         $.assign_call,
+        $.index_call,
         alias($.index_operator, $.index_call),
         $.special_variable,
       ))
@@ -2308,6 +2302,7 @@ module.exports = grammar({
         $.instance_var,
         $.class_var,
         $.assign_call,
+        $.index_call,
         alias($.index_operator, $.index_call),
       ))
       const rhs = field('rhs', $._expression)
@@ -2322,6 +2317,7 @@ module.exports = grammar({
       $.instance_var,
       $.class_var,
       $.assign_call,
+      $.index_call,
       alias($.index_operator, $.index_call),
     )),
 
@@ -2331,6 +2327,7 @@ module.exports = grammar({
         $.instance_var,
         $.class_var,
         $.assign_call,
+        $.index_call,
         alias($.index_operator, $.index_call),
       )
       const lhs_splat = field('lhs', alias($.lhs_splat, $.splat))

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -793,6 +793,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "index_call"
+        },
+        {
+          "type": "SYMBOL",
           "name": "assign"
         },
         {
@@ -7664,99 +7668,39 @@
             "value": "."
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "FIELD",
-                "name": "method",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "identifier"
-                    },
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "identifier_method_call"
-                      },
-                      "named": true,
-                      "value": "identifier"
-                    },
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "_operator_token"
-                      },
-                      "named": true,
-                      "value": "operator"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "instance_var"
-                    }
-                  ]
+            "type": "FIELD",
+            "name": "method",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "identifier_method_call"
+                  },
+                  "named": true,
+                  "value": "identifier"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_operator_token"
+                  },
+                  "named": true,
+                  "value": "operator"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "instance_var"
                 }
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "FIELD",
-                    "name": "method",
-                    "content": {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "STRING",
-                        "value": "["
-                      },
-                      "named": true,
-                      "value": "operator"
-                    }
-                  },
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "bracket_argument_list"
-                    },
-                    "named": true,
-                    "value": "argument_list"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "]"
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "IMMEDIATE_TOKEN",
-                            "content": {
-                              "type": "STRING",
-                              "value": "?"
-                            }
-                          },
-                          {
-                            "type": "STRING",
-                            "value": "="
-                          }
-                        ]
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
+              ]
+            }
           }
         ]
       }
@@ -9335,6 +9279,58 @@
         ]
       }
     },
+    "index_call": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "receiver",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "."
+        },
+        {
+          "type": "FIELD",
+          "name": "method",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "["
+            },
+            "named": true,
+            "value": "operator"
+          }
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "bracket_argument_list"
+          },
+          "named": true,
+          "value": "argument_list"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "]"
+            },
+            {
+              "type": "STRING",
+              "value": "]?"
+            }
+          ]
+        }
+      ]
+    },
     "not": {
       "type": "PREC",
       "value": "unary_operator",
@@ -10388,6 +10384,10 @@
                   "name": "assign_call"
                 },
                 {
+                  "type": "SYMBOL",
+                  "name": "index_call"
+                },
+                {
                   "type": "ALIAS",
                   "content": {
                     "type": "SYMBOL",
@@ -10490,6 +10490,10 @@
                 {
                   "type": "SYMBOL",
                   "name": "assign_call"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "index_call"
                 },
                 {
                   "type": "ALIAS",
@@ -10614,6 +10618,10 @@
               "name": "assign_call"
             },
             {
+              "type": "SYMBOL",
+              "name": "index_call"
+            },
+            {
               "type": "ALIAS",
               "content": {
                 "type": "SYMBOL",
@@ -10696,6 +10704,10 @@
                                   "name": "assign_call"
                                 },
                                 {
+                                  "type": "SYMBOL",
+                                  "name": "index_call"
+                                },
+                                {
                                   "type": "ALIAS",
                                   "content": {
                                     "type": "SYMBOL",
@@ -10749,6 +10761,10 @@
                           {
                             "type": "SYMBOL",
                             "name": "assign_call"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "index_call"
                           },
                           {
                             "type": "ALIAS",
@@ -10881,6 +10897,10 @@
                                   "name": "assign_call"
                                 },
                                 {
+                                  "type": "SYMBOL",
+                                  "name": "index_call"
+                                },
+                                {
                                   "type": "ALIAS",
                                   "content": {
                                     "type": "SYMBOL",
@@ -10934,6 +10954,10 @@
                           {
                             "type": "SYMBOL",
                             "name": "assign_call"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "index_call"
                           },
                           {
                             "type": "ALIAS",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4004,16 +4004,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "argument_list",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -4372,16 +4362,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "argument_list",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -10265,10 +10245,20 @@
     "fields": {
       "arguments": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "argument_list",
+            "named": true
+          }
+        ]
+      },
+      "method": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "operator",
             "named": true
           }
         ]
@@ -10587,6 +10577,16 @@
           }
         ]
       }
+    },
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        }
+      ]
     }
   },
   {

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -2923,7 +2923,11 @@ a.[count: 1, values: [5]] =0
 b.["q": 1, q?: 3, %q(stuff): [5]] =0
 
 a.[2] %= 5
+c.[0].[0] += 5
+
 a.[0], *b.[0] = 1, 2, 3
+
+a.[0].setter, a.[1].setter = things
 --------------------------------------------------------------------------------
 
 (source_file
@@ -3001,6 +3005,17 @@ a.[0], *b.[0] = 1, 2, 3
       (argument_list
         (integer)))
     rhs: (integer))
+  (op_assign
+    lhs: (index_call
+      receiver: (index_call
+        receiver: (identifier)
+        method: (operator)
+        (argument_list
+          (integer)))
+      method: (operator)
+      (argument_list
+        (integer)))
+    rhs: (integer))
   (multi_assign
     lhs: (index_call
       receiver: (identifier)
@@ -3015,7 +3030,23 @@ a.[0], *b.[0] = 1, 2, 3
           (integer))))
     rhs: (integer)
     rhs: (integer)
-    rhs: (integer)))
+    rhs: (integer))
+  (multi_assign
+    lhs: (assign_call
+      receiver: (index_call
+        receiver: (identifier)
+        method: (operator)
+        (argument_list
+          (integer)))
+      method: (identifier))
+    lhs: (assign_call
+      receiver: (index_call
+        receiver: (identifier)
+        method: (operator)
+        (argument_list
+          (integer)))
+      method: (identifier))
+    rhs: (identifier)))
 
 ================================================================================
 index assignment

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -2873,6 +2873,7 @@ false.|(true)
 nil.
 !()
 
+a.[](1, 2)
 a.[]=(1, 2)
 --------------------------------------------------------------------------------
 
@@ -2899,6 +2900,12 @@ a.[]=(1, 2)
     method: (operator)
     arguments: (argument_list
       (integer)
+      (integer)))
+  (call
+    receiver: (identifier)
+    method: (operator)
+    arguments: (argument_list
+      (integer)
       (integer))))
 
 ================================================================================
@@ -2914,6 +2921,9 @@ ary[*{0}, **{count: 1}]
 
 a.[count: 1, values: [5]] =0
 b.["q": 1, q?: 3, %q(stuff): [5]] =0
+
+a.[2] %= 5
+a.[0], *b.[0] = 1, 2, 3
 --------------------------------------------------------------------------------
 
 (source_file
@@ -2955,35 +2965,57 @@ b.["q": 1, q?: 3, %q(stuff): [5]] =0
           (named_expr
             name: (identifier)
             (integer))))))
-  (call
-    receiver: (identifier)
-    method: (operator)
-    (argument_list
-      (named_expr
-        name: (identifier)
-        (integer))
-      (named_expr
-        name: (identifier)
-        (array
+  (assign
+    lhs: (index_call
+      receiver: (identifier)
+      method: (operator)
+      (argument_list
+        (named_expr
+          name: (identifier)
+          (integer))
+        (named_expr
+          name: (identifier)
+          (array
+            (integer)))))
+    rhs: (integer))
+  (assign
+    lhs: (index_call
+      receiver: (identifier)
+      method: (operator)
+      (argument_list
+        (named_expr
+          name: (string)
+          (integer))
+        (named_expr
+          name: (identifier)
+          (integer))
+        (named_expr
+          name: (string)
+          (array
+            (integer)))))
+    rhs: (integer))
+  (op_assign
+    lhs: (index_call
+      receiver: (identifier)
+      method: (operator)
+      (argument_list
+        (integer)))
+    rhs: (integer))
+  (multi_assign
+    lhs: (index_call
+      receiver: (identifier)
+      method: (operator)
+      (argument_list
+        (integer)))
+    lhs: (splat
+      (index_call
+        receiver: (identifier)
+        method: (operator)
+        (argument_list
           (integer))))
-    arguments: (argument_list
-      (integer)))
-  (call
-    receiver: (identifier)
-    method: (operator)
-    (argument_list
-      (named_expr
-        name: (string)
-        (integer))
-      (named_expr
-        name: (identifier)
-        (integer))
-      (named_expr
-        name: (string)
-        (array
-          (integer))))
-    arguments: (argument_list
-      (integer))))
+    rhs: (integer)
+    rhs: (integer)
+    rhs: (integer)))
 
 ================================================================================
 index assignment


### PR DESCRIPTION
This was a weird structure anyways, and it unintentionally supported illegal syntax like `a.[1] do end`. Now the `_dot_call` rule makes more sense, and assignment with `a.[arg]` syntax is fully supported.

This change shrinks the parser by ~540 states, a 3% decrease.