### PR TITLE
Fix an assertion failure when scanning /

### DIFF
--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1121,6 +1121,8 @@ baz/ 7
 
 begin 1 end / 2
 foo(// // 3)
+
+/a/ .. /b/ / /c/ .../d/
 --------------------------------------------------------------------------------
 
 (source_file
@@ -1195,7 +1197,17 @@ foo(// // 3)
       (op_call
         receiver: (regex)
         operator: (operator)
-        argument: (integer)))))
+        argument: (integer))))
+  (range
+    begin: (range
+      begin: (regex)
+      operator: (operator)
+      end: (op_call
+        receiver: (regex)
+        operator: (operator)
+        argument: (regex)))
+    operator: (operator)
+    end: (regex)))
 
 ================================================================================
 exponential operators


### PR DESCRIPTION
Using the `tree-sitter fuzz` command triggered an assertion failure with this sequence:
```
../
```
The fuzz command gives some other warnings, but they all seem related to whether leading whitespace is counted as part of a token or not. I think this was the only serious failure.