### PR TITLE
Node consistency fixes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -501,16 +501,16 @@ module.exports = grammar({
       $.call,
       alias($.call_with_visibility, $.call),
 
-      alias($.additive_operator, $.op_call),
-      alias($.unary_additive_operator, $.op_call),
-      alias($.multiplicative_operator, $.op_call),
-      alias($.exponential_operator, $.op_call),
-      alias($.shift_operator, $.op_call),
-      alias($.complement_operator, $.op_call),
-      alias($.binary_and_operator, $.op_call),
-      alias($.binary_or_operator, $.op_call),
-      alias($.equality_operator, $.op_call),
-      alias($.comparison_operator, $.op_call),
+      alias($.additive_operator, $.call),
+      alias($.unary_additive_operator, $.call),
+      alias($.multiplicative_operator, $.call),
+      alias($.exponential_operator, $.call),
+      alias($.shift_operator, $.call),
+      alias($.complement_operator, $.call),
+      alias($.binary_and_operator, $.call),
+      alias($.binary_or_operator, $.call),
+      alias($.equality_operator, $.call),
+      alias($.comparison_operator, $.call),
       alias($.index_operator, $.index_call),
       $.index_call,
       $.assign,
@@ -2039,8 +2039,8 @@ module.exports = grammar({
       )
 
       const receiver = field('receiver', $._expression)
-      const method = field('operator', alias(operator, $.operator))
-      const arg = field('argument', $._expression)
+      const method = field('method', alias(operator, $.operator))
+      const arg = field('arguments', alias($._expression, $.argument_list))
 
       return prec.left('additive_operator',
         seq(receiver, method, arg),
@@ -2056,7 +2056,7 @@ module.exports = grammar({
       )
 
       return prec('unary_operator', seq(
-        field('operator', alias(operator, $.operator)),
+        field('method', alias(operator, $.operator)),
         field('receiver', $._expression),
       ))
     },
@@ -2071,8 +2071,8 @@ module.exports = grammar({
       )
 
       const receiver = field('receiver', $._expression)
-      const method = field('operator', alias(operator, $.operator))
-      const arg = field('argument', $._expression)
+      const method = field('method', alias(operator, $.operator))
+      const arg = field('arguments', alias($._expression, $.argument_list))
 
       return prec.left('multiplicative_operator', seq(
         receiver, method, arg,
@@ -2083,8 +2083,8 @@ module.exports = grammar({
       const operator = choice($._binary_double_star, '&**')
 
       const receiver = field('receiver', $._expression)
-      const method = field('operator', alias(operator, $.operator))
-      const arg = field('argument', $._expression)
+      const method = field('method', alias(operator, $.operator))
+      const arg = field('arguments', alias($._expression, $.argument_list))
 
       return prec.right('exponential_operator', seq(
         receiver, method, arg,
@@ -2095,8 +2095,8 @@ module.exports = grammar({
       const operator = choice('<<', '>>')
 
       const receiver = field('receiver', $._expression)
-      const method = field('operator', alias(operator, $.operator))
-      const arg = field('argument', $._expression)
+      const method = field('method', alias(operator, $.operator))
+      const arg = field('arguments', alias($._expression, $.argument_list))
 
       return prec.left('shift_operator', seq(
         receiver, method, arg,
@@ -2107,7 +2107,7 @@ module.exports = grammar({
       const operator = '~'
 
       return prec('unary_operator', seq(
-        field('operator', alias(operator, $.operator)),
+        field('method', alias(operator, $.operator)),
         field('receiver', $._expression),
       ))
     },
@@ -2115,8 +2115,8 @@ module.exports = grammar({
     binary_and_operator: $ => {
       const operator = $.binary_ampersand
       const receiver = field('receiver', $._expression)
-      const method = field('operator', alias(operator, $.operator))
-      const arg = field('argument', $._expression)
+      const method = field('method', alias(operator, $.operator))
+      const arg = field('arguments', alias($._expression, $.argument_list))
 
       return prec.left('binary_and_operator', seq(
         receiver, method, arg,
@@ -2126,8 +2126,8 @@ module.exports = grammar({
     binary_or_operator: $ => {
       const operator = choice('|', '^')
       const receiver = field('receiver', $._expression)
-      const method = field('operator', alias(operator, $.operator))
-      const arg = field('argument', $._expression)
+      const method = field('method', alias(operator, $.operator))
+      const arg = field('arguments', alias($._expression, $.argument_list))
 
       return prec.left('binary_or_operator', seq(
         receiver, method, arg,
@@ -2137,8 +2137,8 @@ module.exports = grammar({
     equality_operator: $ => {
       const operator = choice('==', '!=', '=~', '!~', '===')
       const receiver = field('receiver', $._expression)
-      const method = field('operator', alias(operator, $.operator))
-      const arg = field('argument', $._expression)
+      const method = field('method', alias(operator, $.operator))
+      const arg = field('arguments', alias($._expression, $.argument_list))
 
       return prec.left('equality_operator', seq(
         receiver, method, arg,
@@ -2148,8 +2148,8 @@ module.exports = grammar({
     comparison_operator: $ => {
       const operator = choice('<', '<=', '>', '>=', '<=>')
       const receiver = field('receiver', $._expression)
-      const method = field('operator', alias(operator, $.operator))
-      const arg = field('argument', $._expression)
+      const method = field('method', alias(operator, $.operator))
+      const arg = field('arguments', alias($._expression, $.argument_list))
 
       return prec.left('comparison_operator', seq(
         receiver, method, arg,

--- a/grammar.js
+++ b/grammar.js
@@ -2487,7 +2487,7 @@ module.exports = grammar({
 
     while: $ => seq(
       'while',
-      field('condition', $._expression),
+      field('cond', $._expression),
       $._terminator,
       field('body', seq(optional(alias($._statements, $.expressions)))),
       'end',
@@ -2495,7 +2495,7 @@ module.exports = grammar({
 
     until: $ => seq(
       'until',
-      field('condition', $._expression),
+      field('cond', $._expression),
       $._terminator,
       field('body', seq(optional(alias($._statements, $.expressions)))),
       'end',

--- a/grammar.js
+++ b/grammar.js
@@ -467,7 +467,7 @@ module.exports = grammar({
       // Groupings
       alias($.empty_parens, $.nil),
       alias($.parenthesized_expressions, $.expressions),
-      $.begin_block,
+      $.begin,
 
       // Symbols
       $.self,
@@ -2423,7 +2423,7 @@ module.exports = grammar({
       ))
     },
 
-    begin_block: $ => seq(
+    begin: $ => seq(
       'begin',
       optional($._terminator),
       field('body', seq(optional(alias($._statements, $.expressions)))),
@@ -2431,7 +2431,7 @@ module.exports = grammar({
       'end',
     ),
 
-    rescue_block: $ => {
+    rescue: $ => {
       const rescue_variable = field('variable', $.identifier)
       const rescue_type = field('type', $._bare_type)
       const rescue_body = field('body', seq(optional(alias($._statements, $.expressions))))
@@ -2467,17 +2467,17 @@ module.exports = grammar({
     _rescue_else_ensure: $ => {
       return choice(
         seq(
-          field('rescue', repeat1($.rescue_block)),
+          field('rescue', repeat1($.rescue)),
           field('else', optional($.else)),
           field('ensure', optional($.ensure)),
         ),
         seq(
-          field('rescue', repeat($.rescue_block)),
+          field('rescue', repeat($.rescue)),
           field('else', $.else),
           field('ensure', optional($.ensure)),
         ),
         seq(
-          field('rescue', repeat($.rescue_block)),
+          field('rescue', repeat($.rescue)),
           field('else', optional($.else)),
           field('ensure', $.ensure),
         ),

--- a/grammar.js
+++ b/grammar.js
@@ -384,7 +384,7 @@ module.exports = grammar({
     _statement: $ => choice(
       $._expression,
       $.const_assign,
-      $.multi_assign,
+      alias($.multi_assign, $.assign),
       $.annotation,
       $.annotation_def,
       $.module_def,

--- a/grammar.js
+++ b/grammar.js
@@ -2026,9 +2026,20 @@ module.exports = grammar({
       )
     },
 
-    not: $ => prec('unary_operator', seq('!', $._expression)),
-    and: $ => prec.left('logical_and_operator', seq($._expression, '&&', $._expression)),
-    or: $ => prec.left('logical_or_operator', seq($._expression, '||', $._expression)),
+    not: $ => prec('unary_operator', seq(
+      alias('!', $.operator),
+      $._expression,
+    )),
+    and: $ => prec.left('logical_and_operator', seq(
+      $._expression,
+      alias('&&', $.operator),
+      $._expression,
+    )),
+    or: $ => prec.left('logical_or_operator', seq(
+      $._expression,
+      alias('||', $.operator),
+      $._expression,
+    )),
 
     additive_operator: $ => {
       const operator = choice(

--- a/queries/nvim/folds.scm
+++ b/queries/nvim/folds.scm
@@ -1,6 +1,6 @@
 [
   (annotation_def)
-  (begin_block)
+  (begin)
   (block)
   (c_struct_def)
   (case)
@@ -12,7 +12,7 @@
   (lib_def)
   (method_def)
   (module_def)
-  (rescue_block)
+  (rescue)
   (select)
   (struct_def)
   (union_def)

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -568,7 +568,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "begin_block"
+          "name": "begin"
         },
         {
           "type": "SYMBOL",
@@ -11562,7 +11562,7 @@
         ]
       }
     },
-    "begin_block": {
+    "begin": {
       "type": "SEQ",
       "members": [
         {
@@ -11625,7 +11625,7 @@
         }
       ]
     },
-    "rescue_block": {
+    "rescue": {
       "type": "SEQ",
       "members": [
         {
@@ -11814,7 +11814,7 @@
                 "type": "REPEAT1",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "rescue_block"
+                  "name": "rescue"
                 }
               }
             },
@@ -11862,7 +11862,7 @@
                 "type": "REPEAT",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "rescue_block"
+                  "name": "rescue"
                 }
               }
             },
@@ -11902,7 +11902,7 @@
                 "type": "REPEAT",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "rescue_block"
+                  "name": "rescue"
                 }
               }
             },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -11943,7 +11943,7 @@
         },
         {
           "type": "FIELD",
-          "name": "condition",
+          "name": "cond",
           "content": {
             "type": "SYMBOL",
             "name": "_expression"
@@ -11994,7 +11994,7 @@
         },
         {
           "type": "FIELD",
-          "name": "condition",
+          "name": "cond",
           "content": {
             "type": "SYMBOL",
             "name": "_expression"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9359,8 +9359,13 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "STRING",
-            "value": "!"
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "!"
+            },
+            "named": true,
+            "value": "operator"
           },
           {
             "type": "SYMBOL",
@@ -9380,8 +9385,13 @@
             "name": "_expression"
           },
           {
-            "type": "STRING",
-            "value": "&&"
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "&&"
+            },
+            "named": true,
+            "value": "operator"
           },
           {
             "type": "SYMBOL",
@@ -9401,8 +9411,13 @@
             "name": "_expression"
           },
           {
-            "type": "STRING",
-            "value": "||"
+            "type": "ALIAS",
+            "content": {
+              "type": "STRING",
+              "value": "||"
+            },
+            "named": true,
+            "value": "operator"
           },
           {
             "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -210,8 +210,13 @@
           "name": "const_assign"
         },
         {
-          "type": "SYMBOL",
-          "name": "multi_assign"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "multi_assign"
+          },
+          "named": true,
+          "value": "assign"
         },
         {
           "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -667,7 +667,7 @@
             "name": "additive_operator"
           },
           "named": true,
-          "value": "op_call"
+          "value": "call"
         },
         {
           "type": "ALIAS",
@@ -676,7 +676,7 @@
             "name": "unary_additive_operator"
           },
           "named": true,
-          "value": "op_call"
+          "value": "call"
         },
         {
           "type": "ALIAS",
@@ -685,7 +685,7 @@
             "name": "multiplicative_operator"
           },
           "named": true,
-          "value": "op_call"
+          "value": "call"
         },
         {
           "type": "ALIAS",
@@ -694,7 +694,7 @@
             "name": "exponential_operator"
           },
           "named": true,
-          "value": "op_call"
+          "value": "call"
         },
         {
           "type": "ALIAS",
@@ -703,7 +703,7 @@
             "name": "shift_operator"
           },
           "named": true,
-          "value": "op_call"
+          "value": "call"
         },
         {
           "type": "ALIAS",
@@ -712,7 +712,7 @@
             "name": "complement_operator"
           },
           "named": true,
-          "value": "op_call"
+          "value": "call"
         },
         {
           "type": "ALIAS",
@@ -721,7 +721,7 @@
             "name": "binary_and_operator"
           },
           "named": true,
-          "value": "op_call"
+          "value": "call"
         },
         {
           "type": "ALIAS",
@@ -730,7 +730,7 @@
             "name": "binary_or_operator"
           },
           "named": true,
-          "value": "op_call"
+          "value": "call"
         },
         {
           "type": "ALIAS",
@@ -739,7 +739,7 @@
             "name": "equality_operator"
           },
           "named": true,
-          "value": "op_call"
+          "value": "call"
         },
         {
           "type": "ALIAS",
@@ -748,7 +748,7 @@
             "name": "comparison_operator"
           },
           "named": true,
-          "value": "op_call"
+          "value": "call"
         },
         {
           "type": "ALIAS",
@@ -9422,7 +9422,7 @@
           },
           {
             "type": "FIELD",
-            "name": "operator",
+            "name": "method",
             "content": {
               "type": "ALIAS",
               "content": {
@@ -9452,10 +9452,15 @@
           },
           {
             "type": "FIELD",
-            "name": "argument",
+            "name": "arguments",
             "content": {
-              "type": "SYMBOL",
-              "name": "_expression"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              "named": true,
+              "value": "argument_list"
             }
           }
         ]
@@ -9469,7 +9474,7 @@
         "members": [
           {
             "type": "FIELD",
-            "name": "operator",
+            "name": "method",
             "content": {
               "type": "ALIAS",
               "content": {
@@ -9524,7 +9529,7 @@
           },
           {
             "type": "FIELD",
-            "name": "operator",
+            "name": "method",
             "content": {
               "type": "ALIAS",
               "content": {
@@ -9558,10 +9563,15 @@
           },
           {
             "type": "FIELD",
-            "name": "argument",
+            "name": "arguments",
             "content": {
-              "type": "SYMBOL",
-              "name": "_expression"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              "named": true,
+              "value": "argument_list"
             }
           }
         ]
@@ -9583,7 +9593,7 @@
           },
           {
             "type": "FIELD",
-            "name": "operator",
+            "name": "method",
             "content": {
               "type": "ALIAS",
               "content": {
@@ -9605,10 +9615,15 @@
           },
           {
             "type": "FIELD",
-            "name": "argument",
+            "name": "arguments",
             "content": {
-              "type": "SYMBOL",
-              "name": "_expression"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              "named": true,
+              "value": "argument_list"
             }
           }
         ]
@@ -9630,7 +9645,7 @@
           },
           {
             "type": "FIELD",
-            "name": "operator",
+            "name": "method",
             "content": {
               "type": "ALIAS",
               "content": {
@@ -9652,10 +9667,15 @@
           },
           {
             "type": "FIELD",
-            "name": "argument",
+            "name": "arguments",
             "content": {
-              "type": "SYMBOL",
-              "name": "_expression"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              "named": true,
+              "value": "argument_list"
             }
           }
         ]
@@ -9669,7 +9689,7 @@
         "members": [
           {
             "type": "FIELD",
-            "name": "operator",
+            "name": "method",
             "content": {
               "type": "ALIAS",
               "content": {
@@ -9707,7 +9727,7 @@
           },
           {
             "type": "FIELD",
-            "name": "operator",
+            "name": "method",
             "content": {
               "type": "ALIAS",
               "content": {
@@ -9720,10 +9740,15 @@
           },
           {
             "type": "FIELD",
-            "name": "argument",
+            "name": "arguments",
             "content": {
-              "type": "SYMBOL",
-              "name": "_expression"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              "named": true,
+              "value": "argument_list"
             }
           }
         ]
@@ -9745,7 +9770,7 @@
           },
           {
             "type": "FIELD",
-            "name": "operator",
+            "name": "method",
             "content": {
               "type": "ALIAS",
               "content": {
@@ -9767,10 +9792,15 @@
           },
           {
             "type": "FIELD",
-            "name": "argument",
+            "name": "arguments",
             "content": {
-              "type": "SYMBOL",
-              "name": "_expression"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              "named": true,
+              "value": "argument_list"
             }
           }
         ]
@@ -9792,7 +9822,7 @@
           },
           {
             "type": "FIELD",
-            "name": "operator",
+            "name": "method",
             "content": {
               "type": "ALIAS",
               "content": {
@@ -9826,10 +9856,15 @@
           },
           {
             "type": "FIELD",
-            "name": "argument",
+            "name": "arguments",
             "content": {
-              "type": "SYMBOL",
-              "name": "_expression"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              "named": true,
+              "value": "argument_list"
             }
           }
         ]
@@ -9851,7 +9886,7 @@
           },
           {
             "type": "FIELD",
-            "name": "operator",
+            "name": "method",
             "content": {
               "type": "ALIAS",
               "content": {
@@ -9885,10 +9920,15 @@
           },
           {
             "type": "FIELD",
-            "name": "argument",
+            "name": "arguments",
             "content": {
-              "type": "SYMBOL",
-              "name": "_expression"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_expression"
+              },
+              "named": true,
+              "value": "argument_list"
             }
           }
         ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -370,6 +370,10 @@
           "named": true
         },
         {
+          "type": "operator",
+          "named": true
+        },
+        {
           "type": "or",
           "named": true
         },
@@ -9974,7 +9978,7 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
         {
@@ -10099,6 +10103,10 @@
         },
         {
           "type": "op_assign",
+          "named": true
+        },
+        {
+          "type": "operator",
           "named": true
         },
         {
@@ -10628,6 +10636,10 @@
         },
         {
           "type": "op_assign",
+          "named": true
+        },
+        {
+          "type": "operator",
           "named": true
         },
         {
@@ -15177,10 +15189,6 @@
     "named": false
   },
   {
-    "type": "&&",
-    "named": false
-  },
-  {
     "type": "&&=",
     "named": false
   },
@@ -15690,10 +15698,6 @@
   },
   {
     "type": "|=",
-    "named": false
-  },
-  {
-    "type": "||",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -262,7 +262,7 @@
           "named": true
         },
         {
-          "type": "begin_block",
+          "type": "begin",
           "named": true
         },
         {
@@ -515,7 +515,7 @@
           "named": true
         },
         {
-          "type": "begin_block",
+          "type": "begin",
           "named": true
         },
         {
@@ -817,7 +817,7 @@
           "named": true
         },
         {
-          "type": "begin_block",
+          "type": "begin",
           "named": true
         },
         {
@@ -1109,7 +1109,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -1385,7 +1385,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -1607,7 +1607,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -1795,7 +1795,7 @@
     }
   },
   {
-    "type": "begin_block",
+    "type": "begin",
     "named": true,
     "fields": {
       "body": {
@@ -1833,7 +1833,7 @@
         "required": false,
         "types": [
           {
-            "type": "rescue_block",
+            "type": "rescue",
             "named": true
           }
         ]
@@ -1889,7 +1889,7 @@
         "required": false,
         "types": [
           {
-            "type": "rescue_block",
+            "type": "rescue",
             "named": true
           }
         ]
@@ -1921,7 +1921,7 @@
           "named": true
         },
         {
-          "type": "begin_block",
+          "type": "begin",
           "named": true
         },
         {
@@ -2409,7 +2409,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -2673,7 +2673,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -2885,7 +2885,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -3289,7 +3289,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -3495,7 +3495,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -3701,7 +3701,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -3939,7 +3939,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -4238,7 +4238,7 @@
           "named": true
         },
         {
-          "type": "begin_block",
+          "type": "begin",
           "named": true
         },
         {
@@ -4569,7 +4569,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -4821,7 +4821,7 @@
           "named": true
         },
         {
-          "type": "begin_block",
+          "type": "begin",
           "named": true
         },
         {
@@ -5227,7 +5227,7 @@
           "named": true
         },
         {
-          "type": "begin_block",
+          "type": "begin",
           "named": true
         },
         {
@@ -6095,7 +6095,7 @@
           "named": true
         },
         {
-          "type": "begin_block",
+          "type": "begin",
           "named": true
         },
         {
@@ -6337,7 +6337,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -6726,7 +6726,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -7020,7 +7020,7 @@
           "named": true
         },
         {
-          "type": "begin_block",
+          "type": "begin",
           "named": true
         },
         {
@@ -7333,7 +7333,7 @@
         "required": false,
         "types": [
           {
-            "type": "rescue_block",
+            "type": "rescue",
             "named": true
           }
         ]
@@ -7505,7 +7505,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -7728,7 +7728,7 @@
           "named": true
         },
         {
-          "type": "begin_block",
+          "type": "begin",
           "named": true
         },
         {
@@ -8011,7 +8011,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -8233,7 +8233,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -8517,7 +8517,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -8740,7 +8740,7 @@
           "named": true
         },
         {
-          "type": "begin_block",
+          "type": "begin",
           "named": true
         },
         {
@@ -9023,7 +9023,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -9245,7 +9245,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -9584,7 +9584,7 @@
           "named": true
         },
         {
-          "type": "begin_block",
+          "type": "begin",
           "named": true
         },
         {
@@ -9994,7 +9994,7 @@
           "named": true
         },
         {
-          "type": "begin_block",
+          "type": "begin",
           "named": true
         },
         {
@@ -10306,7 +10306,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -10523,7 +10523,7 @@
           "named": true
         },
         {
-          "type": "begin_block",
+          "type": "begin",
           "named": true
         },
         {
@@ -10738,7 +10738,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -11459,7 +11459,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -11665,7 +11665,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -11913,7 +11913,7 @@
     }
   },
   {
-    "type": "rescue_block",
+    "type": "rescue",
     "named": true,
     "fields": {
       "body": {
@@ -12138,7 +12138,7 @@
           "named": true
         },
         {
-          "type": "begin_block",
+          "type": "begin",
           "named": true
         },
         {
@@ -12715,7 +12715,7 @@
           "named": true
         },
         {
-          "type": "begin_block",
+          "type": "begin",
           "named": true
         },
         {
@@ -12998,7 +12998,7 @@
           "named": true
         },
         {
-          "type": "begin_block",
+          "type": "begin",
           "named": true
         },
         {
@@ -13350,7 +13350,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -13647,7 +13647,7 @@
           "named": true
         },
         {
-          "type": "begin_block",
+          "type": "begin",
           "named": true
         },
         {
@@ -14041,7 +14041,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -14283,7 +14283,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -14505,7 +14505,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -14731,7 +14731,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {
@@ -14943,7 +14943,7 @@
             "named": true
           },
           {
-            "type": "begin_block",
+            "type": "begin",
             "named": true
           },
           {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -370,10 +370,6 @@
           "named": true
         },
         {
-          "type": "op_call",
-          "named": true
-        },
-        {
           "type": "or",
           "named": true
         },
@@ -636,10 +632,6 @@
         },
         {
           "type": "op_assign",
-          "named": true
-        },
-        {
-          "type": "op_call",
           "named": true
         },
         {
@@ -930,10 +922,6 @@
         },
         {
           "type": "op_assign",
-          "named": true
-        },
-        {
-          "type": "op_call",
           "named": true
         },
         {
@@ -1229,10 +1217,6 @@
             "named": true
           },
           {
-            "type": "op_call",
-            "named": true
-          },
-          {
             "type": "or",
             "named": true
           },
@@ -1505,10 +1489,6 @@
             "named": true
           },
           {
-            "type": "op_call",
-            "named": true
-          },
-          {
             "type": "or",
             "named": true
           },
@@ -1728,10 +1708,6 @@
           },
           {
             "type": "op_assign",
-            "named": true
-          },
-          {
-            "type": "op_call",
             "named": true
           },
           {
@@ -2050,10 +2026,6 @@
         },
         {
           "type": "op_assign",
-          "named": true
-        },
-        {
-          "type": "op_call",
           "named": true
         },
         {
@@ -2541,10 +2513,6 @@
             "named": true
           },
           {
-            "type": "op_call",
-            "named": true
-          },
-          {
             "type": "or",
             "named": true
           },
@@ -2809,10 +2777,6 @@
             "named": true
           },
           {
-            "type": "op_call",
-            "named": true
-          },
-          {
             "type": "or",
             "named": true
           },
@@ -3022,10 +2986,6 @@
           },
           {
             "type": "op_assign",
-            "named": true
-          },
-          {
-            "type": "op_call",
             "named": true
           },
           {
@@ -3433,10 +3393,6 @@
             "named": true
           },
           {
-            "type": "op_call",
-            "named": true
-          },
-          {
             "type": "or",
             "named": true
           },
@@ -3643,10 +3599,6 @@
             "named": true
           },
           {
-            "type": "op_call",
-            "named": true
-          },
-          {
             "type": "or",
             "named": true
           },
@@ -3850,10 +3802,6 @@
           },
           {
             "type": "op_assign",
-            "named": true
-          },
-          {
-            "type": "op_call",
             "named": true
           },
           {
@@ -4159,10 +4107,6 @@
             "named": true
           },
           {
-            "type": "op_call",
-            "named": true
-          },
-          {
             "type": "or",
             "named": true
           },
@@ -4399,10 +4343,6 @@
         },
         {
           "type": "op_assign",
-          "named": true
-        },
-        {
-          "type": "op_call",
           "named": true
         },
         {
@@ -4737,10 +4677,6 @@
             "named": true
           },
           {
-            "type": "op_call",
-            "named": true
-          },
-          {
             "type": "or",
             "named": true
           },
@@ -5054,10 +4990,6 @@
         },
         {
           "type": "op_assign",
-          "named": true
-        },
-        {
-          "type": "op_call",
           "named": true
         },
         {
@@ -5476,10 +5408,6 @@
         },
         {
           "type": "op_assign",
-          "named": true
-        },
-        {
-          "type": "op_call",
           "named": true
         },
         {
@@ -6283,10 +6211,6 @@
           "named": true
         },
         {
-          "type": "op_call",
-          "named": true
-        },
-        {
           "type": "or",
           "named": true
         },
@@ -6526,10 +6450,6 @@
           },
           {
             "type": "op_assign",
-            "named": true
-          },
-          {
-            "type": "op_call",
             "named": true
           },
           {
@@ -6922,10 +6842,6 @@
             "named": true
           },
           {
-            "type": "op_call",
-            "named": true
-          },
-          {
             "type": "or",
             "named": true
           },
@@ -7217,10 +7133,6 @@
         },
         {
           "type": "op_assign",
-          "named": true
-        },
-        {
-          "type": "op_call",
           "named": true
         },
         {
@@ -7709,10 +7621,6 @@
             "named": true
           },
           {
-            "type": "op_call",
-            "named": true
-          },
-          {
             "type": "or",
             "named": true
           },
@@ -8000,10 +7908,6 @@
           "named": true
         },
         {
-          "type": "op_call",
-          "named": true
-        },
-        {
           "type": "or",
           "named": true
         },
@@ -8224,10 +8128,6 @@
           },
           {
             "type": "op_assign",
-            "named": true
-          },
-          {
-            "type": "op_call",
             "named": true
           },
           {
@@ -8514,10 +8414,6 @@
           },
           {
             "type": "op_assign",
-            "named": true
-          },
-          {
-            "type": "op_call",
             "named": true
           },
           {
@@ -8745,10 +8641,6 @@
             "named": true
           },
           {
-            "type": "op_call",
-            "named": true
-          },
-          {
             "type": "or",
             "named": true
           },
@@ -9036,10 +8928,6 @@
           "named": true
         },
         {
-          "type": "op_call",
-          "named": true
-        },
-        {
           "type": "or",
           "named": true
         },
@@ -9260,10 +9148,6 @@
           },
           {
             "type": "op_assign",
-            "named": true
-          },
-          {
-            "type": "op_call",
             "named": true
           },
           {
@@ -9550,10 +9434,6 @@
           },
           {
             "type": "op_assign",
-            "named": true
-          },
-          {
-            "type": "op_call",
             "named": true
           },
           {
@@ -9851,10 +9731,6 @@
             "named": true
           },
           {
-            "type": "op_call",
-            "named": true
-          },
-          {
             "type": "or",
             "named": true
           },
@@ -10079,10 +9955,6 @@
         },
         {
           "type": "op_assign",
-          "named": true
-        },
-        {
-          "type": "op_call",
           "named": true
         },
         {
@@ -10496,10 +10368,6 @@
           "named": true
         },
         {
-          "type": "op_call",
-          "named": true
-        },
-        {
           "type": "or",
           "named": true
         },
@@ -10812,446 +10680,6 @@
             "named": true
           },
           {
-            "type": "op_call",
-            "named": true
-          },
-          {
-            "type": "or",
-            "named": true
-          },
-          {
-            "type": "proc",
-            "named": true
-          },
-          {
-            "type": "pseudo_constant",
-            "named": true
-          },
-          {
-            "type": "range",
-            "named": true
-          },
-          {
-            "type": "regex",
-            "named": true
-          },
-          {
-            "type": "select",
-            "named": true
-          },
-          {
-            "type": "self",
-            "named": true
-          },
-          {
-            "type": "sizeof",
-            "named": true
-          },
-          {
-            "type": "special_variable",
-            "named": true
-          },
-          {
-            "type": "string",
-            "named": true
-          },
-          {
-            "type": "symbol",
-            "named": true
-          },
-          {
-            "type": "true",
-            "named": true
-          },
-          {
-            "type": "tuple",
-            "named": true
-          },
-          {
-            "type": "type_declaration",
-            "named": true
-          },
-          {
-            "type": "typeof",
-            "named": true
-          },
-          {
-            "type": "unless",
-            "named": true
-          },
-          {
-            "type": "until",
-            "named": true
-          },
-          {
-            "type": "while",
-            "named": true
-          },
-          {
-            "type": "yield",
-            "named": true
-          }
-        ]
-      }
-    }
-  },
-  {
-    "type": "op_call",
-    "named": true,
-    "fields": {
-      "argument": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "and",
-            "named": true
-          },
-          {
-            "type": "array",
-            "named": true
-          },
-          {
-            "type": "asm",
-            "named": true
-          },
-          {
-            "type": "assign",
-            "named": true
-          },
-          {
-            "type": "begin_block",
-            "named": true
-          },
-          {
-            "type": "call",
-            "named": true
-          },
-          {
-            "type": "case",
-            "named": true
-          },
-          {
-            "type": "chained_string",
-            "named": true
-          },
-          {
-            "type": "char",
-            "named": true
-          },
-          {
-            "type": "class_var",
-            "named": true
-          },
-          {
-            "type": "command",
-            "named": true
-          },
-          {
-            "type": "conditional",
-            "named": true
-          },
-          {
-            "type": "constant",
-            "named": true
-          },
-          {
-            "type": "expressions",
-            "named": true
-          },
-          {
-            "type": "false",
-            "named": true
-          },
-          {
-            "type": "float",
-            "named": true
-          },
-          {
-            "type": "generic_instance_type",
-            "named": true
-          },
-          {
-            "type": "hash",
-            "named": true
-          },
-          {
-            "type": "heredoc_start",
-            "named": true
-          },
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "if",
-            "named": true
-          },
-          {
-            "type": "index_call",
-            "named": true
-          },
-          {
-            "type": "instance_sizeof",
-            "named": true
-          },
-          {
-            "type": "instance_var",
-            "named": true
-          },
-          {
-            "type": "integer",
-            "named": true
-          },
-          {
-            "type": "method_proc",
-            "named": true
-          },
-          {
-            "type": "named_tuple",
-            "named": true
-          },
-          {
-            "type": "nil",
-            "named": true
-          },
-          {
-            "type": "not",
-            "named": true
-          },
-          {
-            "type": "offsetof",
-            "named": true
-          },
-          {
-            "type": "op_assign",
-            "named": true
-          },
-          {
-            "type": "op_call",
-            "named": true
-          },
-          {
-            "type": "or",
-            "named": true
-          },
-          {
-            "type": "proc",
-            "named": true
-          },
-          {
-            "type": "pseudo_constant",
-            "named": true
-          },
-          {
-            "type": "range",
-            "named": true
-          },
-          {
-            "type": "regex",
-            "named": true
-          },
-          {
-            "type": "select",
-            "named": true
-          },
-          {
-            "type": "self",
-            "named": true
-          },
-          {
-            "type": "sizeof",
-            "named": true
-          },
-          {
-            "type": "special_variable",
-            "named": true
-          },
-          {
-            "type": "string",
-            "named": true
-          },
-          {
-            "type": "symbol",
-            "named": true
-          },
-          {
-            "type": "true",
-            "named": true
-          },
-          {
-            "type": "tuple",
-            "named": true
-          },
-          {
-            "type": "type_declaration",
-            "named": true
-          },
-          {
-            "type": "typeof",
-            "named": true
-          },
-          {
-            "type": "unless",
-            "named": true
-          },
-          {
-            "type": "until",
-            "named": true
-          },
-          {
-            "type": "while",
-            "named": true
-          },
-          {
-            "type": "yield",
-            "named": true
-          }
-        ]
-      },
-      "operator": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "operator",
-            "named": true
-          }
-        ]
-      },
-      "receiver": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "and",
-            "named": true
-          },
-          {
-            "type": "array",
-            "named": true
-          },
-          {
-            "type": "asm",
-            "named": true
-          },
-          {
-            "type": "assign",
-            "named": true
-          },
-          {
-            "type": "begin_block",
-            "named": true
-          },
-          {
-            "type": "call",
-            "named": true
-          },
-          {
-            "type": "case",
-            "named": true
-          },
-          {
-            "type": "chained_string",
-            "named": true
-          },
-          {
-            "type": "char",
-            "named": true
-          },
-          {
-            "type": "class_var",
-            "named": true
-          },
-          {
-            "type": "command",
-            "named": true
-          },
-          {
-            "type": "conditional",
-            "named": true
-          },
-          {
-            "type": "constant",
-            "named": true
-          },
-          {
-            "type": "expressions",
-            "named": true
-          },
-          {
-            "type": "false",
-            "named": true
-          },
-          {
-            "type": "float",
-            "named": true
-          },
-          {
-            "type": "generic_instance_type",
-            "named": true
-          },
-          {
-            "type": "hash",
-            "named": true
-          },
-          {
-            "type": "heredoc_start",
-            "named": true
-          },
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "if",
-            "named": true
-          },
-          {
-            "type": "index_call",
-            "named": true
-          },
-          {
-            "type": "instance_sizeof",
-            "named": true
-          },
-          {
-            "type": "instance_var",
-            "named": true
-          },
-          {
-            "type": "integer",
-            "named": true
-          },
-          {
-            "type": "method_proc",
-            "named": true
-          },
-          {
-            "type": "named_tuple",
-            "named": true
-          },
-          {
-            "type": "nil",
-            "named": true
-          },
-          {
-            "type": "not",
-            "named": true
-          },
-          {
-            "type": "offsetof",
-            "named": true
-          },
-          {
-            "type": "op_assign",
-            "named": true
-          },
-          {
-            "type": "op_call",
-            "named": true
-          },
-          {
             "type": "or",
             "named": true
           },
@@ -11469,10 +10897,6 @@
           "named": true
         },
         {
-          "type": "op_call",
-          "named": true
-        },
-        {
           "type": "or",
           "named": true
         },
@@ -11685,10 +11109,6 @@
           },
           {
             "type": "op_assign",
-            "named": true
-          },
-          {
-            "type": "op_call",
             "named": true
           },
           {
@@ -12413,10 +11833,6 @@
             "named": true
           },
           {
-            "type": "op_call",
-            "named": true
-          },
-          {
             "type": "or",
             "named": true
           },
@@ -12620,10 +12036,6 @@
           },
           {
             "type": "op_assign",
-            "named": true
-          },
-          {
-            "type": "op_call",
             "named": true
           },
           {
@@ -13097,10 +12509,6 @@
         },
         {
           "type": "op_assign",
-          "named": true
-        },
-        {
-          "type": "op_call",
           "named": true
         },
         {
@@ -13745,10 +13153,6 @@
           "named": true
         },
         {
-          "type": "op_call",
-          "named": true
-        },
-        {
           "type": "or",
           "named": true
         },
@@ -13973,10 +13377,6 @@
         },
         {
           "type": "op_assign",
-          "named": true
-        },
-        {
-          "type": "op_call",
           "named": true
         },
         {
@@ -14328,10 +13728,6 @@
             "named": true
           },
           {
-            "type": "op_call",
-            "named": true
-          },
-          {
             "type": "or",
             "named": true
           },
@@ -14626,10 +14022,6 @@
         },
         {
           "type": "op_assign",
-          "named": true
-        },
-        {
-          "type": "op_call",
           "named": true
         },
         {
@@ -15027,10 +14419,6 @@
             "named": true
           },
           {
-            "type": "op_call",
-            "named": true
-          },
-          {
             "type": "or",
             "named": true
           },
@@ -15273,10 +14661,6 @@
             "named": true
           },
           {
-            "type": "op_call",
-            "named": true
-          },
-          {
             "type": "or",
             "named": true
           },
@@ -15503,10 +14887,6 @@
             "named": true
           },
           {
-            "type": "op_call",
-            "named": true
-          },
-          {
             "type": "or",
             "named": true
           },
@@ -15729,10 +15109,6 @@
             "named": true
           },
           {
-            "type": "op_call",
-            "named": true
-          },
-          {
             "type": "or",
             "named": true
           },
@@ -15942,10 +15318,6 @@
           },
           {
             "type": "op_assign",
-            "named": true
-          },
-          {
-            "type": "op_call",
             "named": true
           },
           {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1331,7 +1331,7 @@
     "named": true,
     "fields": {
       "lhs": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
@@ -1357,11 +1357,15 @@
           {
             "type": "special_variable",
             "named": true
+          },
+          {
+            "type": "splat",
+            "named": true
           }
         ]
       },
       "rhs": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
@@ -4079,10 +4083,6 @@
             "named": true
           },
           {
-            "type": "multi_assign",
-            "named": true
-          },
-          {
             "type": "named_tuple",
             "named": true
           },
@@ -4965,10 +4965,6 @@
           "named": true
         },
         {
-          "type": "multi_assign",
-          "named": true
-        },
-        {
           "type": "named_tuple",
           "named": true
         },
@@ -5380,10 +5376,6 @@
         },
         {
           "type": "module_def",
-          "named": true
-        },
-        {
-          "type": "multi_assign",
           "named": true
         },
         {
@@ -7880,10 +7872,6 @@
           "named": true
         },
         {
-          "type": "multi_assign",
-          "named": true
-        },
-        {
           "type": "named_tuple",
           "named": true
         },
@@ -8386,10 +8374,6 @@
           },
           {
             "type": "module_def",
-            "named": true
-          },
-          {
-            "type": "multi_assign",
             "named": true
           },
           {
@@ -8900,10 +8884,6 @@
           "named": true
         },
         {
-          "type": "multi_assign",
-          "named": true
-        },
-        {
           "type": "named_tuple",
           "named": true
         },
@@ -9409,10 +9389,6 @@
             "named": true
           },
           {
-            "type": "multi_assign",
-            "named": true
-          },
-          {
             "type": "named_tuple",
             "named": true
           },
@@ -9562,248 +9538,6 @@
         "types": [
           {
             "type": "private",
-            "named": true
-          }
-        ]
-      }
-    }
-  },
-  {
-    "type": "multi_assign",
-    "named": true,
-    "fields": {
-      "lhs": {
-        "multiple": true,
-        "required": true,
-        "types": [
-          {
-            "type": "assign_call",
-            "named": true
-          },
-          {
-            "type": "class_var",
-            "named": true
-          },
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "index_call",
-            "named": true
-          },
-          {
-            "type": "instance_var",
-            "named": true
-          },
-          {
-            "type": "splat",
-            "named": true
-          }
-        ]
-      },
-      "rhs": {
-        "multiple": true,
-        "required": true,
-        "types": [
-          {
-            "type": "and",
-            "named": true
-          },
-          {
-            "type": "array",
-            "named": true
-          },
-          {
-            "type": "asm",
-            "named": true
-          },
-          {
-            "type": "assign",
-            "named": true
-          },
-          {
-            "type": "begin_block",
-            "named": true
-          },
-          {
-            "type": "call",
-            "named": true
-          },
-          {
-            "type": "case",
-            "named": true
-          },
-          {
-            "type": "chained_string",
-            "named": true
-          },
-          {
-            "type": "char",
-            "named": true
-          },
-          {
-            "type": "class_var",
-            "named": true
-          },
-          {
-            "type": "command",
-            "named": true
-          },
-          {
-            "type": "conditional",
-            "named": true
-          },
-          {
-            "type": "constant",
-            "named": true
-          },
-          {
-            "type": "expressions",
-            "named": true
-          },
-          {
-            "type": "false",
-            "named": true
-          },
-          {
-            "type": "float",
-            "named": true
-          },
-          {
-            "type": "generic_instance_type",
-            "named": true
-          },
-          {
-            "type": "hash",
-            "named": true
-          },
-          {
-            "type": "heredoc_start",
-            "named": true
-          },
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "if",
-            "named": true
-          },
-          {
-            "type": "index_call",
-            "named": true
-          },
-          {
-            "type": "instance_sizeof",
-            "named": true
-          },
-          {
-            "type": "instance_var",
-            "named": true
-          },
-          {
-            "type": "integer",
-            "named": true
-          },
-          {
-            "type": "method_proc",
-            "named": true
-          },
-          {
-            "type": "named_tuple",
-            "named": true
-          },
-          {
-            "type": "nil",
-            "named": true
-          },
-          {
-            "type": "not",
-            "named": true
-          },
-          {
-            "type": "offsetof",
-            "named": true
-          },
-          {
-            "type": "op_assign",
-            "named": true
-          },
-          {
-            "type": "or",
-            "named": true
-          },
-          {
-            "type": "proc",
-            "named": true
-          },
-          {
-            "type": "pseudo_constant",
-            "named": true
-          },
-          {
-            "type": "range",
-            "named": true
-          },
-          {
-            "type": "regex",
-            "named": true
-          },
-          {
-            "type": "select",
-            "named": true
-          },
-          {
-            "type": "self",
-            "named": true
-          },
-          {
-            "type": "sizeof",
-            "named": true
-          },
-          {
-            "type": "special_variable",
-            "named": true
-          },
-          {
-            "type": "string",
-            "named": true
-          },
-          {
-            "type": "symbol",
-            "named": true
-          },
-          {
-            "type": "true",
-            "named": true
-          },
-          {
-            "type": "tuple",
-            "named": true
-          },
-          {
-            "type": "type_declaration",
-            "named": true
-          },
-          {
-            "type": "typeof",
-            "named": true
-          },
-          {
-            "type": "unless",
-            "named": true
-          },
-          {
-            "type": "until",
-            "named": true
-          },
-          {
-            "type": "while",
-            "named": true
-          },
-          {
-            "type": "yield",
             "named": true
           }
         ]
@@ -13122,10 +12856,6 @@
         },
         {
           "type": "module_def",
-          "named": true
-        },
-        {
-          "type": "multi_assign",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -14262,7 +14262,7 @@
           }
         ]
       },
-      "condition": {
+      "cond": {
         "multiple": false,
         "required": true,
         "types": [
@@ -14710,7 +14710,7 @@
           }
         ]
       },
-      "condition": {
+      "cond": {
         "multiple": false,
         "required": true,
         "types": [

--- a/test/corpus/errors.txt
+++ b/test/corpus/errors.txt
@@ -290,12 +290,12 @@ puts(** foo)
 (expressions
   (ERROR
     (constant))
-  (op_call
-    (operator)
-    (assign
-      (identifier)
+  (call
+    method: (operator)
+    receiver: (assign
+      lhs: (identifier)
       (ERROR)
-      (regex
+      rhs: (regex
         (MISSING "/")))))
 
 ================================================================================
@@ -357,9 +357,9 @@ q
     (heredoc_start)
     (heredoc_start)
     (ERROR)
-    (op_call
-      (operator)
-      (identifier)))
+    (call
+      method: (operator)
+      receiver: (identifier)))
   (heredoc_body
     (heredoc_content)
     (heredoc_end))
@@ -429,19 +429,20 @@ b = <<-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 (expressions
   (comment)
   (assign
-    (identifier)
-    (heredoc_start))
+    lhs: (identifier)
+    rhs: (heredoc_start))
   (heredoc_body
     (heredoc_content)
     (heredoc_end))
   (comment)
-  (op_call
-    (identifier)
+  (call
+    receiver: (identifier)
     (ERROR)
-    (operator)
-    (op_call
-      (operator)
-      (identifier)))
+    method: (operator)
+    arguments: (argument_list
+      (call
+        method: (operator)
+        receiver: (identifier))))
   (identifier)
   (identifier))
 
@@ -467,10 +468,10 @@ p <<-🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥�
 
 (expressions
   (comment)
-  (op_call
-    (call
-      (identifier)
-      (argument_list
+  (call
+    receiver: (call
+      method: (identifier)
+      arguments: (argument_list
         (heredoc_start)
         (heredoc_start)
         (heredoc_start)
@@ -478,10 +479,11 @@ p <<-🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥�
         (heredoc_start)
         (heredoc_start)))
     (ERROR)
-    (operator)
-    (op_call
-      (operator)
-      (identifier)))
+    method: (operator)
+    arguments: (argument_list
+      (call
+        method: (operator)
+        receiver: (identifier))))
   (heredoc_body
     (heredoc_content)
     (heredoc_end))
@@ -509,13 +511,14 @@ missing_quote
 --------------------------------------------------------------------------------
 
 (expressions
-  (op_call
-    (MISSING identifier)
-    (operator)
-    (op_call
-      (operator)
-      (ERROR)
-      (identifier)))
+  (call
+    receiver: (MISSING identifier)
+    method: (operator)
+    arguments: (argument_list
+      (call
+        method: (operator)
+        (ERROR)
+        receiver: (identifier))))
   (identifier))
 
 ================================================================================

--- a/test/corpus/errors.txt
+++ b/test/corpus/errors.txt
@@ -57,7 +57,7 @@ end
 --------------------------------------------------------------------------------
 
 (expressions
-  (begin_block
+  (begin
     (comment)
     (comment)
     (comment)
@@ -66,7 +66,7 @@ end
       (UNEXPECTED 127)
       (ignored_backslash)
       (operator)))
-  (begin_block
+  (begin
     (comment)
     (ERROR
       (ignored_backslash)

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -783,18 +783,18 @@ begin begin end end
 --------------------------------------------------------------------------------
 
 (expressions
-  (begin_block
+  (begin
     body: (expressions
       (integer)))
-  (begin_block
+  (begin
     body: (expressions
       (integer)))
-  (begin_block
+  (begin
     body: (expressions
-      (begin_block)))
-  (begin_block
+      (begin)))
+  (begin
     body: (expressions
-      (begin_block))))
+      (begin))))
 
 ================================================================================
 begin blocks with rescue
@@ -825,29 +825,29 @@ end
 --------------------------------------------------------------------------------
 
 (expressions
-  (begin_block
+  (begin
     body: (expressions
       (integer))
-    rescue: (rescue_block
+    rescue: (rescue
       body: (expressions
         (integer))))
-  (begin_block
+  (begin
     body: (expressions
       (integer))
-    rescue: (rescue_block
+    rescue: (rescue
       body: (expressions
         (integer))))
-  (begin_block
+  (begin
     body: (expressions
       (integer))
-    rescue: (rescue_block
+    rescue: (rescue
       variable: (identifier)
       body: (expressions
         (integer))))
-  (begin_block
+  (begin
     body: (expressions
       (integer))
-    rescue: (rescue_block
+    rescue: (rescue
       type: (constant)
       body: (expressions
         (integer)
@@ -857,10 +857,10 @@ end
             var: (identifier)
             type: (constant)))
         (integer))))
-  (begin_block
+  (begin
     body: (expressions
       (integer))
-    rescue: (rescue_block
+    rescue: (rescue
       variable: (identifier)
       type: (union_type
         (constant)
@@ -885,12 +885,12 @@ puts begin 1
 --------------------------------------------------------------------------------
 
 (expressions
-  (begin_block
+  (begin
     body: (expressions
       (integer))
     ensure: (ensure
       (integer)))
-  (begin_block
+  (begin
     body: (expressions
       (modifier_ensure
         (identifier)
@@ -900,7 +900,7 @@ puts begin 1
   (call
     method: (identifier)
     arguments: (argument_list
-      (begin_block
+      (begin
         body: (expressions
           (integer)
           (integer)
@@ -930,7 +930,7 @@ begin :a; rescue; :b else :c; ensure p! :d end
 --------------------------------------------------------------------------------
 
 (expressions
-  (begin_block
+  (begin
     body: (expressions
       (modifier_rescue
         (integer)
@@ -938,7 +938,7 @@ begin :a; rescue; :b else :c; ensure p! :d end
           var: (identifier)
           type: (constant)))
       (integer))
-    rescue: (rescue_block
+    rescue: (rescue
       variable: (identifier)
       body: (expressions
         (integer)))
@@ -947,10 +947,10 @@ begin :a; rescue; :b else :c; ensure p! :d end
         (integer)))
     ensure: (ensure
       (integer)))
-  (begin_block
+  (begin
     body: (expressions
       (symbol))
-    rescue: (rescue_block
+    rescue: (rescue
       body: (expressions
         (symbol)))
     else: (else
@@ -961,10 +961,10 @@ begin :a; rescue; :b else :c; ensure p! :d end
             method: (identifier)
             arguments: (argument_list
               (symbol)))))))
-  (begin_block
+  (begin
     body: (expressions
       (symbol))
-    rescue: (rescue_block
+    rescue: (rescue
       body: (expressions
         (symbol)))
     else: (else
@@ -1309,7 +1309,7 @@ foo(// // 3)
     arguments: (argument_list
       (integer)))
   (call
-    receiver: (begin_block
+    receiver: (begin
       body: (expressions
         (integer)))
     method: (operator)
@@ -2207,7 +2207,7 @@ end
   (call
     method: (identifier)
     block: (block
-      rescue: (rescue_block
+      rescue: (rescue
         variable: (identifier))))
   (call
     method: (identifier)
@@ -2227,7 +2227,7 @@ end
           name: (identifier)))
       body: (expressions
         (symbol))
-      rescue: (rescue_block)
+      rescue: (rescue)
       else: (else)
       ensure: (ensure))))
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1500,30 +1500,40 @@ d && e || f && g
 
 (expressions
   (not
+    (operator)
     (identifier))
   (or
     (call
       receiver: (identifier)
       method: (identifier))
+    (operator)
     (identifier))
   (and
     (identifier)
+    (operator)
     (identifier))
   (or
     (not
+      (operator)
       (true))
+    (operator)
     (false))
   (or
     (identifier)
+    (operator)
     (and
       (identifier)
+      (operator)
       (identifier)))
   (or
     (and
       (identifier)
+      (operator)
       (identifier))
+    (operator)
     (and
       (identifier)
+      (operator)
       (identifier))))
 
 ================================================================================

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -48,10 +48,11 @@ end
           (call
             method: (identifier)
             arguments: (argument_list
-              (op_call
+              (call
                 receiver: (instance_var)
-                operator: (operator)
-                argument: (integer))))))
+                method: (operator)
+                arguments: (argument_list
+                  (integer)))))))
       (method_def
         name: (identifier)
         params: (param_list
@@ -167,28 +168,31 @@ parentheses and expressions
         (expressions
           (expressions
             (nil))))))
-  (op_call
-    receiver: (op_call
+  (call
+    receiver: (call
       receiver: (expressions
-        (op_call
+        (call
           receiver: (expressions
             (nil)
             (integer))
-          operator: (operator)
-          argument: (expressions
-            (integer))))
-      operator: (operator)
-      argument: (expressions
+          method: (operator)
+          arguments: (argument_list
+            (expressions
+              (integer)))))
+      method: (operator)
+      arguments: (argument_list
         (expressions
-          (integer))))
-    operator: (operator)
-    argument: (expressions
+          (expressions
+            (integer)))))
+    method: (operator)
+    arguments: (argument_list
       (expressions
-        (integer)
-        (op_call
-          operator: (operator)
-          receiver: (expressions
-            (integer)))))))
+        (expressions
+          (integer)
+          (call
+            method: (operator)
+            receiver: (expressions
+              (integer))))))))
 
 ================================================================================
 method calls
@@ -352,19 +356,21 @@ pp(*a+b, *c*d, *e = f)
 --------------------------------------------------------------------------------
 
 (expressions
-  (op_call
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (identifier))
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
   (call
     method: (identifier)
     arguments: (argument_list
       (splat
         (identifier))))
-  (op_call
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (identifier))
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
   (call
     method: (identifier)
     arguments: (argument_list
@@ -383,15 +389,17 @@ pp(*a+b, *c*d, *e = f)
     method: (identifier)
     arguments: (argument_list
       (splat
-        (op_call
+        (call
           receiver: (identifier)
-          operator: (operator)
-          argument: (identifier)))
+          method: (operator)
+          arguments: (argument_list
+            (identifier))))
       (splat
-        (op_call
+        (call
           receiver: (identifier)
-          operator: (operator)
-          argument: (identifier)))
+          method: (operator)
+          arguments: (argument_list
+            (identifier))))
       (splat
         (assign
           lhs: (identifier)
@@ -409,19 +417,21 @@ pp **{a: 1, "b": 2.0, C: -3, }, **{c: nil}
 --------------------------------------------------------------------------------
 
 (expressions
-  (op_call
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (identifier))
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
   (call
     method: (identifier)
     arguments: (argument_list
       (double_splat
         (identifier))))
-  (op_call
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (identifier))
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
   (call
     method: (identifier)
     arguments: (argument_list
@@ -499,8 +509,8 @@ bar 1, c: + 2,
       (integer)
       (named_expr
         name: (identifier)
-        (op_call
-          operator: (operator)
+        (call
+          method: (operator)
           receiver: (integer)))
       (named_expr
         name: (identifier)
@@ -1045,32 +1055,37 @@ puts "a" + "b".upcase
 --------------------------------------------------------------------------------
 
 (expressions
-  (op_call
+  (call
     receiver: (integer)
-    operator: (operator)
-    argument: (float))
-  (op_call
-    receiver: (op_call
+    method: (operator)
+    arguments: (argument_list
+      (float)))
+  (call
+    receiver: (call
       receiver: (identifier)
-      operator: (operator)
-      argument: (call
-        method: (identifier)))
-    operator: (operator)
-    argument: (constant))
-  (op_call
-    receiver: (constant)
-    operator: (operator)
-    argument: (expressions
+      method: (operator)
+      arguments: (argument_list
+        (call
+          method: (identifier))))
+    method: (operator)
+    arguments: (argument_list
       (constant)))
+  (call
+    receiver: (constant)
+    method: (operator)
+    arguments: (argument_list
+      (expressions
+        (constant))))
   (call
     method: (identifier)
     arguments: (argument_list
-      (op_call
+      (call
         receiver: (string)
-        operator: (operator)
-        argument: (call
-          receiver: (string)
-          method: (identifier))))))
+        method: (operator)
+        arguments: (argument_list
+          (call
+            receiver: (string)
+            method: (identifier)))))))
 
 ================================================================================
 unary additive operators
@@ -1103,86 +1118,94 @@ d_ (- 2)
 --------------------------------------------------------------------------------
 
 (expressions
-  (op_call
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (integer))
+    method: (operator)
+    arguments: (argument_list
+      (integer)))
   (call
     method: (identifier)
     arguments: (argument_list
       (integer)))
-  (op_call
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (integer))
+    method: (operator)
+    arguments: (argument_list
+      (integer)))
   (call
     method: (identifier)
     arguments: (argument_list
-      (op_call
-        operator: (operator)
+      (call
+        method: (operator)
         receiver: (integer))))
-  (op_call
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (integer))
+    method: (operator)
+    arguments: (argument_list
+      (integer)))
   (call
     method: (identifier)
     arguments: (argument_list
-      (op_call
-        operator: (operator)
+      (call
+        method: (operator)
         receiver: (integer))))
-  (op_call
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (integer))
+    method: (operator)
+    arguments: (argument_list
+      (integer)))
   (call
     method: (identifier)
     arguments: (argument_list
-      (op_call
-        operator: (operator)
+      (call
+        method: (operator)
         receiver: (integer))))
-  (op_call
+  (call
     receiver: (call
       method: (identifier))
-    operator: (operator)
-    argument: (integer))
+    method: (operator)
+    arguments: (argument_list
+      (integer)))
   (call
     method: (identifier)
     arguments: (argument_list
       (integer)))
-  (op_call
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (integer))
+    method: (operator)
+    arguments: (argument_list
+      (integer)))
   (call
     method: (identifier)
     arguments: (argument_list
       (expressions
-        (op_call
-          operator: (operator)
+        (call
+          method: (operator)
           receiver: (integer)))))
-  (op_call
-    operator: (operator)
-    receiver: (op_call
-      operator: (operator)
+  (call
+    method: (operator)
+    receiver: (call
+      method: (operator)
       receiver: (integer)))
-  (op_call
-    operator: (operator)
-    receiver: (op_call
-      operator: (operator)
+  (call
+    method: (operator)
+    receiver: (call
+      method: (operator)
       receiver: (float)))
-  (op_call
+  (call
     receiver: (integer)
-    operator: (operator)
-    argument: (integer))
-  (op_call
+    method: (operator)
+    arguments: (argument_list
+      (integer)))
+  (call
     receiver: (integer)
-    operator: (operator)
-    argument: (op_call
-      operator: (operator)
-      receiver: (integer)))
-  (op_call
-    operator: (operator)
+    method: (operator)
+    arguments: (argument_list
+      (call
+        method: (operator)
+        receiver: (integer))))
+  (call
+    method: (operator)
     receiver: (call
       receiver: (integer)
       method: (identifier))))
@@ -1211,88 +1234,104 @@ foo(// // 3)
 --------------------------------------------------------------------------------
 
 (expressions
-  (op_call
-    receiver: (op_call
-      receiver: (op_call
-        receiver: (op_call
-          receiver: (op_call
+  (call
+    receiver: (call
+      receiver: (call
+        receiver: (call
+          receiver: (call
             receiver: (integer)
-            operator: (operator)
-            argument: (integer))
-          operator: (operator)
-          argument: (float))
-        operator: (operator)
-        argument: (float))
-      operator: (operator)
-      argument: (integer))
-    operator: (operator)
-    argument: (identifier))
+            method: (operator)
+            arguments: (argument_list
+              (integer)))
+          method: (operator)
+          arguments: (argument_list
+            (float)))
+        method: (operator)
+        arguments: (argument_list
+          (float)))
+      method: (operator)
+      arguments: (argument_list
+        (integer)))
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
   (call
     method: (identifier)
     arguments: (argument_list
       (range
-        begin: (op_call
+        begin: (call
           receiver: (integer)
-          operator: (operator)
-          argument: (integer))
+          method: (operator)
+          arguments: (argument_list
+            (integer)))
         operator: (operator)
-        end: (op_call
+        end: (call
           receiver: (integer)
-          operator: (operator)
-          argument: (float)))))
+          method: (operator)
+          arguments: (argument_list
+            (float))))))
   (call
     method: (identifier)
     arguments: (argument_list
-      (op_call
+      (call
         receiver: (integer)
-        operator: (operator)
-        argument: (op_call
-          receiver: (float)
-          operator: (operator)
-          argument: (integer)))))
-  (op_call
+        method: (operator)
+        arguments: (argument_list
+          (call
+            receiver: (float)
+            method: (operator)
+            arguments: (argument_list
+              (integer)))))))
+  (call
     receiver: (call
       method: (identifier))
-    operator: (operator)
-    argument: (identifier))
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
   (call
     method: (identifier)
     arguments: (argument_list
       (regex)))
-  (op_call
+  (call
     receiver: (expressions
       (identifier))
-    operator: (operator)
-    argument: (identifier))
-  (op_call
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (identifier))
-  (op_call
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (integer))
-  (op_call
+    method: (operator)
+    arguments: (argument_list
+      (integer)))
+  (call
     receiver: (begin_block
       body: (expressions
         (integer)))
-    operator: (operator)
-    argument: (integer))
+    method: (operator)
+    arguments: (argument_list
+      (integer)))
   (call
     method: (identifier)
     arguments: (argument_list
-      (op_call
+      (call
         receiver: (regex)
-        operator: (operator)
-        argument: (integer))))
+        method: (operator)
+        arguments: (argument_list
+          (integer)))))
   (range
     begin: (range
       begin: (regex)
       operator: (operator)
-      end: (op_call
+      end: (call
         receiver: (regex)
-        operator: (operator)
-        argument: (regex)))
+        method: (operator)
+        arguments: (argument_list
+          (regex))))
     operator: (operator)
     end: (regex)))
 
@@ -1308,27 +1347,32 @@ puts 2 **
 --------------------------------------------------------------------------------
 
 (expressions
-  (op_call
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (op_call
-      receiver: (constant)
-      operator: (operator)
-      argument: (integer)))
+    method: (operator)
+    arguments: (argument_list
+      (call
+        receiver: (constant)
+        method: (operator)
+        arguments: (argument_list
+          (integer)))))
   (call
     method: (identifier)
     arguments: (argument_list
-      (op_call
+      (call
         receiver: (integer)
-        operator: (operator)
-        argument: (integer))))
-  (op_call
+        method: (operator)
+        arguments: (argument_list
+          (integer)))))
+  (call
     receiver: (float)
-    operator: (operator)
-    argument: (op_call
-      receiver: (integer)
-      operator: (operator)
-      argument: (constant))))
+    method: (operator)
+    arguments: (argument_list
+      (call
+        receiver: (integer)
+        method: (operator)
+        arguments: (argument_list
+          (constant))))))
 
 ================================================================================
 shift operators
@@ -1341,32 +1385,39 @@ array << (13 >> 2)
 --------------------------------------------------------------------------------
 
 (expressions
-  (op_call
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (string))
-  (op_call
-    receiver: (op_call
+    method: (operator)
+    arguments: (argument_list
+      (string)))
+  (call
+    receiver: (call
       receiver: (identifier)
-      operator: (operator)
-      argument: (identifier))
-    operator: (operator)
-    argument: (constant))
-  (op_call
-    receiver: (op_call
+      method: (operator)
+      arguments: (argument_list
+        (identifier)))
+    method: (operator)
+    arguments: (argument_list
+      (constant)))
+  (call
+    receiver: (call
       receiver: (identifier)
-      operator: (operator)
-      argument: (integer))
-    operator: (operator)
-    argument: (integer))
-  (op_call
+      method: (operator)
+      arguments: (argument_list
+        (integer)))
+    method: (operator)
+    arguments: (argument_list
+      (integer)))
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (expressions
-      (op_call
-        receiver: (integer)
-        operator: (operator)
-        argument: (integer)))))
+    method: (operator)
+    arguments: (argument_list
+      (expressions
+        (call
+          receiver: (integer)
+          method: (operator)
+          arguments: (argument_list
+            (integer)))))))
 
 ================================================================================
 binary/bitwise operators
@@ -1381,47 +1432,55 @@ pp [1, 2, 3] | [4, 5, 6] & [1, 4]
 --------------------------------------------------------------------------------
 
 (expressions
-  (op_call
-    receiver: (op_call
-      operator: (operator)
+  (call
+    receiver: (call
+      method: (operator)
       receiver: (integer))
-    operator: (operator)
-    argument: (integer))
-  (op_call
-    receiver: (op_call
+    method: (operator)
+    arguments: (argument_list
+      (integer)))
+  (call
+    receiver: (call
       receiver: (identifier)
-      operator: (operator)
-      argument: (identifier))
-    operator: (operator)
-    argument: (identifier))
-  (op_call
-    receiver: (op_call
+      method: (operator)
+      arguments: (argument_list
+        (identifier)))
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
+  (call
+    receiver: (call
       receiver: (integer)
-      operator: (operator)
-      argument: (identifier))
-    operator: (operator)
-    argument: (op_call
-      receiver: (integer)
-      operator: (operator)
-      argument: (constant)))
+      method: (operator)
+      arguments: (argument_list
+        (identifier)))
+    method: (operator)
+    arguments: (argument_list
+      (call
+        receiver: (integer)
+        method: (operator)
+        arguments: (argument_list
+          (constant)))))
   (call
     method: (identifier)
     arguments: (argument_list
-      (op_call
+      (call
         receiver: (array
           (integer)
           (integer)
           (integer))
-        operator: (operator)
-        argument: (op_call
-          receiver: (array
-            (integer)
-            (integer)
-            (integer))
-          operator: (operator)
-          argument: (array
-            (integer)
-            (integer)))))))
+        method: (operator)
+        arguments: (argument_list
+          (call
+            receiver: (array
+              (integer)
+              (integer)
+              (integer))
+            method: (operator)
+            arguments: (argument_list
+              (array
+                (integer)
+                (integer)))))))))
 
 ================================================================================
 logical operators
@@ -1484,27 +1543,32 @@ e !~ /regex/
 --------------------------------------------------------------------------------
 
 (expressions
-  (op_call
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (identifier))
-  (op_call
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (regex))
-  (op_call
+    method: (operator)
+    arguments: (argument_list
+      (regex)))
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (identifier))
-  (op_call
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (regex))
+    method: (operator)
+    arguments: (argument_list
+      (regex)))
   (expressions
-    (op_call
+    (call
       receiver: (constant)
-      operator: (operator)
-      argument: (symbol))))
+      method: (operator)
+      arguments: (argument_list
+        (symbol)))))
 
 ================================================================================
 comparison operators
@@ -1524,30 +1588,35 @@ p! 0 <=> 5
 --------------------------------------------------------------------------------
 
 (expressions
-  (op_call
+  (call
     receiver: (integer)
-    operator: (operator)
-    argument: (integer))
-  (op_call
+    method: (operator)
+    arguments: (argument_list
+      (integer)))
+  (call
     receiver: (string)
-    operator: (operator)
-    argument: (string))
-  (op_call
+    method: (operator)
+    arguments: (argument_list
+      (string)))
+  (call
     receiver: (integer)
-    operator: (operator)
-    argument: (float))
+    method: (operator)
+    arguments: (argument_list
+      (float)))
   (expressions
-    (op_call
+    (call
       receiver: (integer)
-      operator: (operator)
-      argument: (integer)))
+      method: (operator)
+      arguments: (argument_list
+        (integer))))
   (call
     method: (identifier)
     arguments: (argument_list
-      (op_call
+      (call
         receiver: (integer)
-        operator: (operator)
-        argument: (integer)))))
+        method: (operator)
+        arguments: (argument_list
+          (integer))))))
 
 ================================================================================
 chained equality and comparison operators
@@ -1561,37 +1630,46 @@ a <= b == c
 --------------------------------------------------------------------------------
 
 (expressions
-  (op_call
-    receiver: (op_call
+  (call
+    receiver: (call
       receiver: (identifier)
-      operator: (operator)
-      argument: (identifier))
-    operator: (operator)
-    argument: (identifier))
-  (op_call
-    receiver: (op_call
-      receiver: (op_call
+      method: (operator)
+      arguments: (argument_list
+        (identifier)))
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
+  (call
+    receiver: (call
+      receiver: (call
         receiver: (identifier)
-        operator: (operator)
-        argument: (identifier))
-      operator: (operator)
-      argument: (identifier))
-    operator: (operator)
-    argument: (identifier))
-  (op_call
-    receiver: (op_call
+        method: (operator)
+        arguments: (argument_list
+          (identifier)))
+      method: (operator)
+      arguments: (argument_list
+        (identifier)))
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
+  (call
+    receiver: (call
       receiver: (identifier)
-      operator: (operator)
-      argument: (identifier))
-    operator: (operator)
-    argument: (identifier))
-  (op_call
+      method: (operator)
+      arguments: (argument_list
+        (identifier)))
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (op_call
-      receiver: (identifier)
-      operator: (operator)
-      argument: (identifier))))
+    method: (operator)
+    arguments: (argument_list
+      (call
+        receiver: (identifier)
+        method: (operator)
+        arguments: (argument_list
+          (identifier))))))
 
 ================================================================================
 combined assignment operators
@@ -2823,64 +2901,70 @@ func &(-var)
 
 (expressions
   (comment)
-  (op_call
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (identifier))
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
   (comment)
   (call
     method: (identifier)
     arguments: (argument_list
-      (op_call
-        operator: (operator)
+      (call
+        method: (operator)
         receiver: (identifier))))
   (comment)
   (call
     method: (identifier)
     arguments: (argument_list
-      (op_call
-        operator: (operator)
+      (call
+        method: (operator)
         receiver: (identifier))))
   (comment)
-  (op_call
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (identifier))
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
   (comment)
   (call
     method: (identifier)
     arguments: (argument_list
-      (op_call
-        operator: (operator)
+      (call
+        method: (operator)
         receiver: (identifier))))
   (comment)
   (call
     method: (identifier)
     arguments: (argument_list
-      (op_call
-        operator: (operator)
+      (call
+        method: (operator)
         receiver: (identifier))))
   (comment)
-  (op_call
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (identifier))
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
   (comment)
-  (op_call
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (proc
-      block: (block)))
-  (op_call
+    method: (operator)
+    arguments: (argument_list
+      (proc
+        block: (block))))
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (identifier))
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
   (comment)
-  (op_call
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (proc
-      block: (block)))
+    method: (operator)
+    arguments: (argument_list
+      (proc
+        block: (block))))
   (call
     receiver: (identifier)
     method: (operator))
@@ -2935,16 +3019,16 @@ func &(-var)
     arguments: (argument_list
       (block_argument
         (expressions
-          (op_call
-            operator: (operator)
+          (call
+            method: (operator)
             receiver: (identifier))))))
   (call
     method: (identifier)
     arguments: (argument_list
       (block_argument
         (expressions
-          (op_call
-            operator: (operator)
+          (call
+            method: (operator)
             receiver: (identifier)))))))
 
 ================================================================================
@@ -3038,10 +3122,11 @@ end
         (argument_list
           (splat
             (identifier))))
-      (op_call
+      (call
         receiver: (yield)
-        operator: (operator)
-        argument: (yield)))))
+        method: (operator)
+        arguments: (argument_list
+          (yield))))))
 
 ================================================================================
 operator method calls
@@ -3445,10 +3530,11 @@ end
                         type: (constant)))
                     block: (block
                       body: (expressions
-                        (op_call
+                        (call
                           receiver: (identifier)
-                          operator: (operator)
-                          argument: (integer))))))))))))))
+                          method: (operator)
+                          arguments: (argument_list
+                            (integer)))))))))))))))
 
 ================================================================================
 exhaustive case expressions
@@ -3846,14 +3932,16 @@ end
           (integer)))
       (return
         (argument_list
-          (op_call
+          (call
             receiver: (integer)
-            operator: (operator)
-            argument: (integer))
-          (op_call
+            method: (operator)
+            arguments: (argument_list
+              (integer)))
+          (call
             receiver: (integer)
-            operator: (operator)
-            argument: (integer))
+            method: (operator)
+            arguments: (argument_list
+              (integer)))
           (call
             receiver: (identifier)
             method: (identifier)

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -668,28 +668,28 @@ a, b, c = d.val, e.val, f = {1, 2, 3}
 --------------------------------------------------------------------------------
 
 (expressions
-  (multi_assign
+  (assign
     lhs: (identifier)
     lhs: (identifier)
     rhs: (identifier)
     rhs: (identifier))
-  (multi_assign
+  (assign
     lhs: (splat
       (identifier))
     rhs: (tuple
       (integer)))
-  (multi_assign
+  (assign
     lhs: (splat
       (identifier))
     rhs: (integer)
     rhs: (integer)
     rhs: (integer))
-  (multi_assign
+  (assign
     lhs: (identifier)
     lhs: (identifier)
     lhs: (identifier)
     rhs: (identifier))
-  (multi_assign
+  (assign
     lhs: (identifier)
     lhs: (splat
       (instance_var))
@@ -697,7 +697,7 @@ a, b, c = d.val, e.val, f = {1, 2, 3}
     rhs: (integer)
     rhs: (integer)
     rhs: (integer))
-  (multi_assign
+  (assign
     lhs: (identifier)
     lhs: (identifier)
     rhs: (assign
@@ -706,7 +706,7 @@ a, b, c = d.val, e.val, f = {1, 2, 3}
     rhs: (assign
       lhs: (identifier)
       rhs: (integer)))
-  (multi_assign
+  (assign
     lhs: (assign_call
       receiver: (identifier)
       method: (identifier))
@@ -715,7 +715,7 @@ a, b, c = d.val, e.val, f = {1, 2, 3}
       method: (identifier))
     rhs: (symbol)
     rhs: (symbol))
-  (multi_assign
+  (assign
     lhs: (identifier)
     lhs: (identifier)
     lhs: (identifier)
@@ -3282,7 +3282,7 @@ a.[0].setter, a.[1].setter = things
       (argument_list
         (integer)))
     rhs: (integer))
-  (multi_assign
+  (assign
     lhs: (index_call
       receiver: (identifier)
       method: (operator)
@@ -3297,7 +3297,7 @@ a.[0].setter, a.[1].setter = things
     rhs: (integer)
     rhs: (integer)
     rhs: (integer))
-  (multi_assign
+  (assign
     lhs: (assign_call
       receiver: (index_call
         receiver: (identifier)
@@ -3339,7 +3339,7 @@ a[1], *b[0] = a
       arguments: (argument_list
         (integer)))
     rhs: (integer))
-  (multi_assign
+  (assign
     lhs: (index_call
       receiver: (identifier)
       arguments: (argument_list
@@ -3357,7 +3357,7 @@ a[1], *b[0] = a
       receiver: (identifier)
       arguments: (argument_list
         (integer))))
-  (multi_assign
+  (assign
     lhs: (index_call
       receiver: (identifier)
       arguments: (argument_list

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -750,13 +750,13 @@ end
 
 (expressions
   (while
-    condition: (true))
+    cond: (true))
   (while
-    condition: (integer)
+    cond: (integer)
     body: (expressions
       (next)))
   (until
-    condition: (call
+    cond: (call
       receiver: (identifier)
       method: (identifier))
     body: (expressions
@@ -764,7 +764,7 @@ end
         lhs: (identifier)
         rhs: (integer))
       (until
-        condition: (identifier)
+        cond: (identifier)
         body: (expressions
           (break))))))
 

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -405,10 +405,11 @@ string interpolation
     (interpolation
       (identifier))
     (interpolation
-      (op_call
+      (call
         receiver: (identifier)
-        operator: (operator)
-        argument: (identifier)))))
+        method: (operator)
+        arguments: (argument_list
+          (identifier))))))
 
 ================================================================================
 nested interpolation stress test
@@ -481,8 +482,8 @@ nested interpolation stress test
                                                 (interpolation
                                                   (string
                                                     (interpolation
-                                                      (op_call
-                                                        receiver: (op_call
+                                                      (call
+                                                        receiver: (call
                                                           receiver: (string
                                                             (interpolation
                                                               (tuple
@@ -492,36 +493,38 @@ nested interpolation stress test
                                                                 (string
                                                                   (interpolation
                                                                     (integer))))))
-                                                          operator: (operator)
-                                                          argument: (string
-                                                            (interpolation
-                                                              (hash
-                                                                (hash_entry
-                                                                  (hash
-                                                                    of_key: (constant)
-                                                                    of_value: (proc_type
-                                                                      (constant)
-                                                                      (constant)
-                                                                      return: (constant)))
-                                                                  (string
-                                                                    (interpolation
-                                                                      (integer))))))))
-                                                        operator: (operator)
-                                                        argument: (string
-                                                          (interpolation
-                                                            (tuple
-                                                              (hash
-                                                                of_key: (constant)
-                                                                of_value: (constant))
-                                                              (string
-                                                                (interpolation
-                                                                  (tuple
+                                                          method: (operator)
+                                                          arguments: (argument_list
+                                                            (string
+                                                              (interpolation
+                                                                (hash
+                                                                  (hash_entry
                                                                     (hash
                                                                       of_key: (constant)
-                                                                      of_value: (constant))
+                                                                      of_value: (proc_type
+                                                                        (constant)
+                                                                        (constant)
+                                                                        return: (constant)))
                                                                     (string
                                                                       (interpolation
-                                                                        (integer)))))))))))))))))))))))))))))))))))))
+                                                                        (integer)))))))))
+                                                        method: (operator)
+                                                        arguments: (argument_list
+                                                          (string
+                                                            (interpolation
+                                                              (tuple
+                                                                (hash
+                                                                  of_key: (constant)
+                                                                  of_value: (constant))
+                                                                (string
+                                                                  (interpolation
+                                                                    (tuple
+                                                                      (hash
+                                                                        of_key: (constant)
+                                                                        of_value: (constant))
+                                                                      (string
+                                                                        (interpolation
+                                                                          (integer))))))))))))))))))))))))))))))))))))))
 
 ================================================================================
 heredoc strings
@@ -650,10 +653,11 @@ A
   (heredoc_body
     (heredoc_content)
     (interpolation
-      (op_call
+      (call
         receiver: (heredoc_start)
-        operator: (operator)
-        argument: (heredoc_start))
+        method: (operator)
+        arguments: (argument_list
+          (heredoc_start)))
       (heredoc_body
         (heredoc_content)
         (heredoc_end))
@@ -828,16 +832,18 @@ p% ()
 
 (expressions
   (string)
-  (op_call
+  (call
     receiver: (identifier)
-    operator: (operator)
-    argument: (nil))
+    method: (operator)
+    arguments: (argument_list
+      (nil)))
   (string)
   (string)
-  (op_call
+  (call
     receiver: (string)
-    operator: (operator)
-    argument: (string))
+    method: (operator)
+    arguments: (argument_list
+      (string)))
   (string)
   (string)
   (string)
@@ -1173,29 +1179,33 @@ regexes
   (regex
     (regex_escape_sequence)
     (regex_modifier))
-  (op_call
+  (call
     receiver: (regex
       (regex_escape_sequence))
-    operator: (operator)
-    argument: (string))
-  (op_call
+    method: (operator)
+    arguments: (argument_list
+      (string)))
+  (call
     receiver: (regex
       (regex_escape_sequence))
-    operator: (operator)
-    argument: (string
-      (string_escape_sequence)))
-  (op_call
+    method: (operator)
+    arguments: (argument_list
+      (string
+        (string_escape_sequence))))
+  (call
     receiver: (regex
       (regex_escape_sequence))
-    operator: (operator)
-    argument: (string
-      (string_escape_sequence)))
-  (op_call
+    method: (operator)
+    arguments: (argument_list
+      (string
+        (string_escape_sequence))))
+  (call
     receiver: (regex
       (regex_escape_sequence))
-    operator: (operator)
-    argument: (string
-      (string_escape_sequence)))
+    method: (operator)
+    arguments: (argument_list
+      (string
+        (string_escape_sequence))))
   (regex
     (regex_escape_sequence))
   (regex
@@ -1210,51 +1220,58 @@ regexes
     (regex_escape_sequence))
   (regex
     (regex_escape_sequence))
-  (op_call
+  (call
     receiver: (regex
       (regex_escape_sequence)
       (regex_escape_sequence))
-    operator: (operator)
-    argument: (string))
-  (op_call
+    method: (operator)
+    arguments: (argument_list
+      (string)))
+  (call
     receiver: (regex
       (regex_character_class))
-    operator: (operator)
-    argument: (string))
-  (op_call
+    method: (operator)
+    arguments: (argument_list
+      (string)))
+  (call
     receiver: (regex
       (regex_character_class))
-    operator: (operator)
-    argument: (string))
-  (op_call
+    method: (operator)
+    arguments: (argument_list
+      (string)))
+  (call
     receiver: (regex
       (regex_character_class))
-    operator: (operator)
-    argument: (string
-      (string_escape_sequence)))
-  (op_call
+    method: (operator)
+    arguments: (argument_list
+      (string
+        (string_escape_sequence))))
+  (call
     receiver: (regex
       (regex_special_match)
       (regex_special_match))
-    operator: (operator)
-    argument: (string))
-  (op_call
+    method: (operator)
+    arguments: (argument_list
+      (string)))
+  (call
     receiver: (regex
       (regex_special_match)
       (regex_character_class)
       (regex_character_class)
       (regex_special_match))
-    operator: (operator)
-    argument: (string))
-  (op_call
+    method: (operator)
+    arguments: (argument_list
+      (string)))
+  (call
     receiver: (regex
       (regex_escape_sequence)
       (regex_escape_sequence)
       (regex_escape_sequence)
       (regex_escape_sequence))
-    operator: (operator)
-    argument: (string
-      (string_escape_sequence)))
+    method: (operator)
+    arguments: (argument_list
+      (string
+        (string_escape_sequence))))
   (regex
     (interpolation
       (regex
@@ -1380,10 +1397,11 @@ hashes
       (integer)))
   (hash
     (hash_entry
-      (op_call
+      (call
         receiver: (integer)
-        operator: (operator)
-        argument: (integer))
+        method: (operator)
+        arguments: (argument_list
+          (integer)))
       (hash
         (hash_entry
           (char)
@@ -1486,15 +1504,16 @@ puts(..)
   (range
     begin: (identifier)
     operator: (operator)
-    end: (op_call
+    end: (call
       receiver: (integer)
-      operator: (operator)
-      argument: (integer)))
+      method: (operator)
+      arguments: (argument_list
+        (integer))))
   (range
     begin: (identifier)
     operator: (operator)
-    end: (op_call
-      operator: (operator)
+    end: (call
+      method: (operator)
       receiver: (identifier)))
   (call
     method: (identifier)
@@ -1676,10 +1695,11 @@ end
     type: (constant)
     block: (block
       body: (expressions
-        (op_call
-          receiver: (identifier)
-          operator: (operator)
-          argument: (identifier)))))
+      (call
+        receiver: (identifier)
+        method: (operator)
+        arguments: (argument_list
+          (identifier))))))
   (proc
     block: (block
       body: (expressions

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -558,7 +558,7 @@ c
   (heredoc_body
     (heredoc_content)
     (heredoc_end))
-  (multi_assign
+  (assign
     lhs: (identifier)
     lhs: (identifier)
     lhs: (identifier)
@@ -1892,7 +1892,7 @@ not_chained = "str1"
 --------------------------------------------------------------------------------
 
 (expressions
-  (multi_assign
+  (assign
     lhs: (identifier)
     lhs: (identifier)
     lhs: (identifier)

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -674,12 +674,12 @@ end
 (expressions
   (method_def
     name: (identifier)
-    rescue: (rescue_block
+    rescue: (rescue
       variable: (identifier)
       type: (union_type
         (constant)
         (constant)))
-    rescue: (rescue_block
+    rescue: (rescue
       variable: (identifier)
       type: (constant))
     else: (else)

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -59,15 +59,16 @@ a + # asdf
 
 (expressions
   (comment)
-  (op_call
+  (call
     receiver: (identifier)
-    operator: (operator)
+    method: (operator)
     (comment)
-    argument: (integer))
+    arguments: (argument_list
+      (integer)))
   (integer)
   (comment)
-  (op_call
-    operator: (operator)
+  (call
+    method: (operator)
     (comment)
     receiver: (integer))
   (comment)
@@ -422,10 +423,11 @@ end
       (call
         method: (identifier)
         arguments: (argument_list
-          (op_call
+          (call
             receiver: (identifier)
-            operator: (operator)
-            argument: (identifier))))))
+            method: (operator)
+            arguments: (argument_list
+              (identifier)))))))
   (method_def
     name: (identifier)
     body: (expressions

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -1033,7 +1033,7 @@ end
 --------------------------------------------------------------------------------
 
 (expressions
-  (multi_assign
+  (assign
     lhs: (identifier)
     lhs: (identifier)
     lhs: (identifier)

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -435,7 +435,9 @@ end
         (expressions
           (or
             (identifier)
+            (operator)
             (identifier)))
+        (operator)
         (identifier)))))
 
 ================================================================================

--- a/test/corpus/todo.txt
+++ b/test/corpus/todo.txt
@@ -1,5 +1,6 @@
 =========
 macro def
+:error
 =========
 
 macro name
@@ -16,6 +17,7 @@ end
 
 ======
 macros
+:error
 ======
 
 {% if true %}
@@ -30,8 +32,8 @@ foo = %var + 4
 (ERROR
   (MISSING identifier)
   (operator)
-  (op_call
-    (op_call
+  (call
+    (call
       (true)
       (ERROR
         (operator))
@@ -54,15 +56,15 @@ foo = %var + 4
     (operator)
     (assign
       (identifier)
-      (op_call
+      (call
         (integer)
         (operator)
         (tuple
           (tuple
             (identifier))))))
   (then
-    (op_call
-      (op_call
+    (call
+      (call
         (identifier)
         (ERROR)
         (operator)
@@ -70,16 +72,16 @@ foo = %var + 4
       (operator)
       (integer))
     (tuple
-      (op_call
-        (op_call
+      (call
+        (call
           (MISSING identifier)
           (operator)
           (identifier))
         (operator)
         (MISSING identifier)))
     (tuple
-      (op_call
-        (op_call
+      (call
+        (call
           (MISSING identifier)
           (operator)
           (identifier))
@@ -223,6 +225,7 @@ end
 
 ============================
 .as method with pointer type
+:error
 ============================
 
 node.as(LibXML::Node*)
@@ -241,6 +244,7 @@ node.as(LibXML::Node*)
 
 ==============================
 instance var with pointer type
+:error
 ==============================
 
 @ivar : UInt8*
@@ -248,7 +252,7 @@ instance var with pointer type
 ---
 
 (expressions
-  (op_call
+  (call
     (type_declaration
       (instance_var)
       (constant))
@@ -281,6 +285,7 @@ StaticArray(Char*, 2)
 
 ==========================
 symbols ending with equals
+:error
 ==========================
 
 :hello=
@@ -294,7 +299,7 @@ symbols ending with equals
   (symbol)
   (ERROR
     (identifier))
-  (op_call
+  (call
     (symbol)
     (operator)
     (identifier)))

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -940,7 +940,7 @@ end
       (assign
         lhs: (identifier)
         rhs: (integer))
-      (multi_assign
+      (assign
         lhs: (identifier)
         lhs: (identifier)
         lhs: (identifier)

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -346,10 +346,11 @@ def p2 : ->(A?1:2); end
     body: (expressions
       (tuple
         (expressions
-          (op_call
+          (call
             receiver: (constant)
-            operator: (operator)
-            argument: (constant))))))
+            method: (operator)
+            arguments: (argument_list
+              (constant)))))))
   (method_def
     name: (identifier)
     type: (proc_type
@@ -361,10 +362,11 @@ def p2 : ->(A?1:2); end
     type: (proc_type)
     body: (expressions
       (expressions
-        (op_call
+        (call
           receiver: (constant)
-          operator: (operator)
-          argument: (constant)))))
+          method: (operator)
+          arguments: (argument_list
+            (constant))))))
   (method_def
     name: (identifier)
     type: (proc_type
@@ -379,10 +381,11 @@ def p2 : ->(A?1:2); end
     type: (proc_type)
     body: (expressions
       (tuple
-        (op_call
+        (call
           receiver: (constant)
-          operator: (operator)
-          argument: (constant)))))
+          method: (operator)
+          arguments: (argument_list
+            (constant))))))
   (method_def
     name: (identifier)
     type: (proc_type
@@ -394,10 +397,11 @@ def p2 : ->(A?1:2); end
     type: (proc_type)
     body: (expressions
       (expressions
-        (op_call
+        (call
           receiver: (constant)
-          operator: (operator)
-          argument: (constant)))))
+          method: (operator)
+          arguments: (argument_list
+            (constant))))))
   (method_def
     name: (identifier)
     type: (proc_type
@@ -1043,10 +1047,11 @@ def p2 : ->{asdf: typeof(FOO)}; end
     type: (tuple_type
       (constant)
       (typeof
-        (op_call
+        (call
           receiver: (integer)
-          operator: (operator)
-          argument: (identifier)))))
+          method: (operator)
+          arguments: (argument_list
+            (identifier))))))
   (method_def
     name: (identifier)
     type: (proc_type)


### PR DESCRIPTION
- Alias `op_call` nodes to `call`, and make their fields the same.
  In other words, these have identical parse trees now: 
  ``` crystal
  1 + 2 + 3
  1.+(2).+(3)
  ```
- Alias `multi_assign` to `assign`. They share `lhs:` and `rhs:` fields, I don't see a reason to keep separate node types.
- Rename `rescue_block` to `rescue` and `begin_block` to `begin`, the `_block suffix was redundant
- Always use `cond` instead of `condition` for field names
- Use `operator` for a few more operators