### PR TITLE
Check for grammar compile warnings

### DIFF
--- a/.github/workflows/compile_check.yml
+++ b/.github/workflows/compile_check.yml
@@ -1,0 +1,55 @@
+name: Compile check
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**.c'
+      - 'src/**.h'
+      - '!src/parser.c'
+  pull_request:
+    paths:
+      - 'src/**.c'
+      - 'src/**.h'
+      - '!src/parser.c'
+
+jobs:
+  compile_check:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            cc: cl
+            clags: "/std:c11 /Wall /WX"
+
+          - os: macos-latest
+            cc: clang
+            cflags: "-std=c11 -Wall -Wextra -Werror -Wstrict-prototypes -Wuninitialized"
+
+          - os: ubuntu-latest
+            cc: gcc
+            cflags: "-std=c11 -Wall -Wextra -Werror -Wstrict-prototypes -Wmaybe-uninitialized"
+
+    runs-on: ${{ matrix.os }}
+
+    env:
+      CC: ${{ matrix.cc }}
+      CFLAGS: ${{ matrix.cflags }}
+
+    name: Parser compilation linting
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up tree-sitter
+        uses: tree-sitter/setup-action/cli@v1
+        with:
+          tree-sitter-ref: latest
+
+      - name: MSVC setup
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Build the grammar
+        run: tree-sitter build

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -501,12 +501,11 @@ static bool scan_heredoc_contents(State *state, TSLexer *lexer, const bool *vali
 
     bool found_content = false;
 
-    Heredoc *active_heredoc;
+    Heredoc *active_heredoc = array_front(&state->heredocs);
     bool heredoc_pending_start;
 
-    if (array_front(&state->heredocs)->started) {
+    if (active_heredoc->started) {
         heredoc_pending_start = false;
-        active_heredoc = array_front(&state->heredocs);
     } else {
         // The first heredoc in the queue isn't started, which means it's a
         // pending nested heredoc that will begin on the next line.

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1335,7 +1335,7 @@ static bool inner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols)
                             max_word_size = MAX_HEREDOC_WORD_SIZE;
                         }
 
-                        uint8_t word[max_word_size + 4];
+                        uint8_t word[HEREDOC_BUFFER_SIZE + 4];
                         size_t word_length = 0;
 
                         // First character must be valid in an identifier, even for a quoted heredoc


### PR DESCRIPTION
Add a new check to verify the grammar builds without warnings on Windows, macOS, and Ubuntu.

Will run if any of the C files _except_ `src/parser.c` is modified. (I assume tree-sitter will always output safe, standards-compliant parser code.)
