### PR TITLE
Use `underscore` in more places

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1615,7 +1615,7 @@ module.exports = grammar({
       alias($.no_args_proc_type, $.proc_type),
       alias($.parenthesized_proc_type, $.proc_type),
       $.class_type,
-      $.underscore_type,
+      $.underscore,
       $.nilable_type,
       $.pointer_type,
       $.self,
@@ -1762,7 +1762,7 @@ module.exports = grammar({
       optional(','),
     ),
 
-    underscore_type: $ => '_',
+    underscore: $ => '_',
 
     nilable_type: $ => prec('atomic_type', seq($._type, '?')),
 
@@ -1990,8 +1990,8 @@ module.exports = grammar({
         repeat(seq(',', $._expression)),
         ',',
       )),
-      $._implicit_object_call,
-      repeat(seq(',', choice($._expression, $._implicit_object_call))),
+      choice($._implicit_object_call, $.underscore),
+      repeat(seq(',', choice($._expression, $._implicit_object_call, $.underscore))),
       optional(','),
       '}',
     ),
@@ -2245,6 +2245,7 @@ module.exports = grammar({
 
     assign: $ => {
       const lhs = field('lhs', choice(
+        $.underscore,
         $.identifier,
         $.instance_var,
         $.class_var,
@@ -2311,6 +2312,7 @@ module.exports = grammar({
     },
 
     lhs_splat: $ => seq('*', choice(
+      $.underscore,
       $.identifier,
       $.instance_var,
       $.class_var,
@@ -2321,6 +2323,7 @@ module.exports = grammar({
 
     multi_assign: $ => {
       const lhs_basic = choice(
+        $.underscore,
         $.identifier,
         $.instance_var,
         $.class_var,

--- a/queries/nvim/highlights.scm
+++ b/queries/nvim/highlights.scm
@@ -89,5 +89,7 @@
   (instance_var)
 ] @variable.member
 
+(underscore) @variable.parameter.builtin
+
 ; function calls
 (call method: (identifier) @function.call)

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6892,7 +6892,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "underscore_type"
+          "name": "underscore"
         },
         {
           "type": "SYMBOL",
@@ -7607,7 +7607,7 @@
         }
       ]
     },
-    "underscore_type": {
+    "underscore": {
       "type": "STRING",
       "value": "_"
     },
@@ -9173,8 +9173,17 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "_implicit_object_call"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_implicit_object_call"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "underscore"
+            }
+          ]
         },
         {
           "type": "REPEAT",
@@ -9195,6 +9204,10 @@
                   {
                     "type": "SYMBOL",
                     "name": "_implicit_object_call"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "underscore"
                   }
                 ]
               }
@@ -10445,6 +10458,10 @@
               "members": [
                 {
                   "type": "SYMBOL",
+                  "name": "underscore"
+                },
+                {
+                  "type": "SYMBOL",
                   "name": "identifier"
                 },
                 {
@@ -10679,6 +10696,10 @@
           "members": [
             {
               "type": "SYMBOL",
+              "name": "underscore"
+            },
+            {
+              "type": "SYMBOL",
               "name": "identifier"
             },
             {
@@ -10765,6 +10786,10 @@
                               "members": [
                                 {
                                   "type": "SYMBOL",
+                                  "name": "underscore"
+                                },
+                                {
+                                  "type": "SYMBOL",
                                   "name": "identifier"
                                 },
                                 {
@@ -10822,6 +10847,10 @@
                       {
                         "type": "CHOICE",
                         "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "underscore"
+                          },
                           {
                             "type": "SYMBOL",
                             "name": "identifier"
@@ -10958,6 +10987,10 @@
                               "members": [
                                 {
                                   "type": "SYMBOL",
+                                  "name": "underscore"
+                                },
+                                {
+                                  "type": "SYMBOL",
                                   "name": "identifier"
                                 },
                                 {
@@ -11015,6 +11048,10 @@
                       {
                         "type": "CHOICE",
                         "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "underscore"
+                          },
                           {
                             "type": "SYMBOL",
                             "name": "identifier"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -116,7 +116,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -216,7 +216,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -790,7 +790,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -1364,6 +1364,10 @@
           },
           {
             "type": "splat",
+            "named": true
+          },
+          {
+            "type": "underscore",
             "named": true
           }
         ]
@@ -2198,7 +2202,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -2329,7 +2333,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -3235,7 +3239,7 @@
           "named": true
         },
         {
-          "type": "underscore_type",
+          "type": "underscore",
           "named": true
         },
         {
@@ -4511,7 +4515,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -5168,7 +5172,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -5665,7 +5669,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -5741,7 +5745,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -5897,7 +5901,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -5983,7 +5987,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -6053,7 +6057,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -6984,7 +6988,7 @@
           "named": true
         },
         {
-          "type": "underscore_type",
+          "type": "underscore",
           "named": true
         },
         {
@@ -7403,7 +7407,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -9876,7 +9880,7 @@
           "named": true
         },
         {
-          "type": "underscore_type",
+          "type": "underscore",
           "named": true
         },
         {
@@ -9963,7 +9967,7 @@
           "named": true
         },
         {
-          "type": "underscore_type",
+          "type": "underscore",
           "named": true
         },
         {
@@ -10253,7 +10257,7 @@
           "named": true
         },
         {
-          "type": "underscore_type",
+          "type": "underscore",
           "named": true
         },
         {
@@ -11024,7 +11028,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -11130,7 +11134,7 @@
           "named": true
         },
         {
-          "type": "underscore_type",
+          "type": "underscore",
           "named": true
         },
         {
@@ -11197,7 +11201,7 @@
           "named": true
         },
         {
-          "type": "underscore_type",
+          "type": "underscore",
           "named": true
         },
         {
@@ -11292,7 +11296,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -11368,7 +11372,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -11431,7 +11435,7 @@
           "named": true
         },
         {
-          "type": "underscore_type",
+          "type": "underscore",
           "named": true
         },
         {
@@ -11999,7 +12003,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -12111,7 +12115,7 @@
           "named": true
         },
         {
-          "type": "underscore_type",
+          "type": "underscore",
           "named": true
         },
         {
@@ -12318,6 +12322,10 @@
           "named": true
         },
         {
+          "type": "underscore",
+          "named": true
+        },
+        {
           "type": "unless",
           "named": true
         },
@@ -12419,7 +12427,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -12497,7 +12505,7 @@
           "named": true
         },
         {
-          "type": "underscore_type",
+          "type": "underscore",
           "named": true
         },
         {
@@ -12580,7 +12588,7 @@
           "named": true
         },
         {
-          "type": "underscore_type",
+          "type": "underscore",
           "named": true
         },
         {
@@ -13182,6 +13190,10 @@
           "named": true
         },
         {
+          "type": "underscore",
+          "named": true
+        },
+        {
           "type": "unless",
           "named": true
         },
@@ -13257,7 +13269,7 @@
           "named": true
         },
         {
-          "type": "underscore_type",
+          "type": "underscore",
           "named": true
         },
         {
@@ -13332,7 +13344,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -13624,7 +13636,7 @@
           "named": true
         },
         {
-          "type": "underscore_type",
+          "type": "underscore",
           "named": true
         },
         {
@@ -13940,7 +13952,7 @@
             "named": true
           },
           {
-            "type": "underscore_type",
+            "type": "underscore",
             "named": true
           },
           {
@@ -14018,7 +14030,7 @@
           "named": true
         },
         {
-          "type": "underscore_type",
+          "type": "underscore",
           "named": true
         },
         {
@@ -15657,7 +15669,7 @@
     "named": false
   },
   {
-    "type": "underscore_type",
+    "type": "underscore",
     "named": true
   },
   {

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -689,14 +689,14 @@ a, b, c = d.val, e.val, f = {1, 2, 3}
     rhs: (integer))
   (assign
     lhs: (identifier)
-    lhs: (identifier)
+    lhs: (underscore)
     lhs: (identifier)
     rhs: (identifier))
   (assign
     lhs: (identifier)
     lhs: (splat
       (instance_var))
-    lhs: (identifier)
+    lhs: (underscore)
     rhs: (integer)
     rhs: (integer)
     rhs: (integer))
@@ -3493,7 +3493,7 @@ end
           method: (identifier))
         (implicit_object_call
           method: (identifier))
-        (identifier))
+        (underscore))
       body: (expressions
         (true)))
     (when
@@ -3504,7 +3504,7 @@ end
           method: (identifier))
         (integer))
       cond: (tuple
-        (identifier)
+        (underscore)
         (identifier)
         (implicit_object_call
           method: (identifier)

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -316,7 +316,7 @@ def p2 : ->(A?1:2); end
     name: (identifier)
     type: (proc_type
       return: (tuple_type
-        (underscore_type))))
+        (underscore))))
   (method_def
     name: (identifier)
     type: (proc_type)
@@ -326,7 +326,7 @@ def p2 : ->(A?1:2); end
   (method_def
     name: (identifier)
     type: (proc_type
-      return: (underscore_type)))
+      return: (underscore)))
   (method_def
     name: (identifier)
     type: (proc_type)
@@ -929,20 +929,20 @@ end
     params: (param_list
       (param
         name: (identifier)
-        type: (underscore_type))
+        type: (underscore))
       (param
         name: (identifier)
         type: (proc_type
-          (underscore_type)
-          (underscore_type)
+          (underscore)
+          (underscore)
           return: (constant))))
     body: (expressions
       (assign
-        lhs: (identifier)
+        lhs: (underscore)
         rhs: (integer))
       (assign
         lhs: (identifier)
-        lhs: (identifier)
+        lhs: (underscore)
         lhs: (identifier)
         rhs: (identifier)))))
 


### PR DESCRIPTION
Make `underscore` a valid node on the left hand side of assignments, and other places