### PR TITLE
Move plain symbols to the external scanner

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -99,6 +99,8 @@ module.exports = grammar({
 
     $._modulo_operator,
 
+    $.unquoted_symbol,
+
     $._string_literal_start,
     $._delimited_string_contents,
     $._string_literal_end,
@@ -742,17 +744,6 @@ module.exports = grammar({
       ':',
       token.immediate(
         choice(...operator_tokens),
-      ),
-    )),
-
-    unquoted_symbol: $ => token(seq(
-      ':',
-      token.immediate(
-        seq(
-          choice(ident_start, const_start),
-          repeat(ident_part),
-          optional(/[?!=]/),
-        ),
       ),
     )),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2753,60 +2753,6 @@
         ]
       }
     },
-    "unquoted_symbol": {
-      "type": "TOKEN",
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": ":"
-          },
-          {
-            "type": "IMMEDIATE_TOKEN",
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "[a-z_\\u{00a0}-\\u{10ffff}]",
-                      "flags": "u"
-                    },
-                    {
-                      "type": "PATTERN",
-                      "value": "[A-Z]"
-                    }
-                  ]
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[0-9A-Za-z_\\u{00a0}-\\u{10ffff}]",
-                    "flags": "u"
-                  }
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "[?!=]"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
-      }
-    },
     "quoted_symbol": {
       "type": "SEQ",
       "members": [
@@ -14289,6 +14235,10 @@
     {
       "type": "SYMBOL",
       "name": "_modulo_operator"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "unquoted_symbol"
     },
     {
       "type": "SYMBOL",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -69,6 +69,8 @@ enum Token {
 
     MODULO_OPERATOR,
 
+    UNQUOTED_SYMBOL,
+
     STRING_LITERAL_START,
     DELIMITED_STRING_CONTENTS,
     STRING_LITERAL_END,
@@ -1901,6 +1903,49 @@ static bool inner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols)
             }
             break;
 
+        case ':':
+            if (valid_symbols[UNQUOTED_SYMBOL]) {
+                lex_advance(lexer);
+
+                int32_t lookahead = lexer->lookahead;
+
+                if (('A' <= lookahead && lookahead <= 'Z')
+                    || ('a' <= lookahead && lookahead <= 'z')
+                    || (lookahead == '_')
+                    || (0x00a0 <= lookahead && lookahead <= 0x10ffffff)) {
+
+                    // This is the start of a symbol
+                    lexer->result_symbol = UNQUOTED_SYMBOL;
+                    lex_advance(lexer);
+
+                    while (is_ident_part(lexer->lookahead)) {
+                        lex_advance(lexer);
+                    }
+
+                    switch (lexer->lookahead) {
+                        case '?':
+                            // Symbols like `:foo?` always include the trailing character
+                            lex_advance(lexer);
+                            return true;
+
+                        case '!':
+                        case '=':
+                            // Symbols like `:foo!` or `:bar=` include the trailing character,
+                            // only if the next char isn't also `=`
+                            lexer->mark_end(lexer);
+                            lex_advance(lexer);
+
+                            if (lexer->lookahead != '=') {
+                                lexer->mark_end(lexer);
+                            }
+                            return true;
+
+                        default:
+                            return true;
+                    }
+                }
+            }
+            break;
         case '.':
             if (valid_symbols[BEGINLESS_RANGE_OPERATOR] && !valid_symbols[START_OF_PARENLESS_ARGS]) {
                 lex_advance(lexer);
@@ -2150,6 +2195,7 @@ bool tree_sitter_crystal_external_scanner_scan(void *payload, TSLexer *lexer, co
     LOG_SYMBOL(REGULAR_ENSURE_KEYWORD);
     LOG_SYMBOL(MODIFIER_ENSURE_KEYWORD);
     LOG_SYMBOL(MODULO_OPERATOR);
+    LOG_SYMBOL(UNQUOTED_SYMBOL);
     LOG_SYMBOL(STRING_LITERAL_START);
     LOG_SYMBOL(DELIMITED_STRING_CONTENTS);
     LOG_SYMBOL(STRING_LITERAL_END);

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -1134,6 +1134,54 @@ symbols
     else: (symbol)))
 
 ================================================================================
+symbols ending in !?=
+:language(crystal)
+================================================================================
+world = "world"
+:hello=
+:world==world
+:world == world
+:world!
+:world!=world
+:world != world
+:world?
+:world?==world
+--------------------------------------------------------------------------------
+
+(expressions
+  (assign
+    lhs: (identifier)
+    rhs: (string))
+  (symbol)
+  (call
+    receiver: (symbol)
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
+  (call
+    receiver: (symbol)
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
+  (symbol)
+  (call
+    receiver: (symbol)
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
+  (call
+    receiver: (symbol)
+    method: (operator)
+    arguments: (argument_list
+      (identifier)))
+  (symbol)
+  (call
+    receiver: (symbol)
+    method: (operator)
+    arguments: (argument_list
+      (identifier))))
+
+================================================================================
 regexes
 :language(crystal)
 ================================================================================

--- a/test/corpus/todo.txt
+++ b/test/corpus/todo.txt
@@ -152,27 +152,6 @@ node.as(LibXML::Node*)
         (operator)
         (MISSING identifier)))))
 
-==========================
-symbols ending with equals
-:error
-==========================
-
-:hello=
-:world==world
-:world == world
-
----
-
-(expressions
-  (symbol)
-  (symbol)
-  (ERROR
-    (identifier))
-  (call
-    (symbol)
-    (operator)
-    (identifier)))
-
 =================================
 case expression with typed tuples
 :error


### PR DESCRIPTION
We need to use lookahead to determine if a symbol ends with `=` or `!`.

I was hoping to use an external token just for the last character, but `token` cannot contain externals :confused: 