### PR TITLE
Split macro_def into two rules

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1346,7 +1346,7 @@ module.exports = grammar({
       ))
     },
 
-    macro_def: $ => {
+    _macro_signature: $ => {
       const visibility = optional(
         field('visibility', choice($.private, $.protected)),
       )
@@ -1369,8 +1369,14 @@ module.exports = grammar({
           name,
           optional(params),
         )),
+      )
+    },
+
+    macro_def: $ => {
+      return seq(
+        $._macro_signature,
         $._terminator,
-        field('body', seq(optional(alias($._statements, $.expressions)))),
+        field('body', optional(alias($._statements, $.expressions))),
         'end',
       )
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5971,7 +5971,7 @@
         ]
       }
     },
-    "macro_def": {
+    "_macro_signature": {
       "type": "SEQ",
       "members": [
         {
@@ -6088,6 +6088,15 @@
               }
             ]
           }
+        }
+      ]
+    },
+    "macro_def": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_macro_signature"
         },
         {
           "type": "SYMBOL",
@@ -6097,24 +6106,19 @@
           "type": "FIELD",
           "name": "body",
           "content": {
-            "type": "SEQ",
+            "type": "CHOICE",
             "members": [
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "_statements"
-                    },
-                    "named": true,
-                    "value": "expressions"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_statements"
+                },
+                "named": true,
+                "value": "expressions"
+              },
+              {
+                "type": "BLANK"
               }
             ]
           }


### PR DESCRIPTION
Just a small optimization that shrinks the parser size.