### PR TITLE
Add folds for multi-line data structures

### DIFF
--- a/queries/nvim/folds.scm
+++ b/queries/nvim/folds.scm
@@ -19,3 +19,12 @@
   (when)
   (while)
 ] @fold
+
+[
+  (array)
+  (array_like)
+  (hash)
+  (hash_like)
+  (named_tuple)
+  (tuple)
+] @fold


### PR DESCRIPTION
Now this can be folded (I love how easy this is):

``` crystal
a = [
  1,
  2,
  3
]
```