### PR TITLE
Add queries for nvim aerial plugin.

### DIFF
--- a/queries/nvim/aerial.scm
+++ b/queries/nvim/aerial.scm
@@ -18,6 +18,10 @@
   name: (identifier) @name
   (#set! "kind" "Method")) @symbol
 
+(macro_def
+  name: (identifier) @name
+  (#set! "kind" "Function")) @symbol
+
 (const_assign
   lhs: (constant) @name
   (#set! "kind" "Constant")) @symbol

--- a/queries/nvim/aerial.scm
+++ b/queries/nvim/aerial.scm
@@ -1,0 +1,23 @@
+(module_def
+  name: (constant) @name
+  (#set! "kind" "Module")) @symbol
+
+(class_def
+  name: (constant) @name
+  (#set! "kind" "Class")) @symbol
+
+(struct_def
+  name: (constant) @name
+  (#set! "kind" "Struct")) @symbol
+
+(enum_def
+  name: (constant) @name
+  (#set! "kind" "Enum")) @symbol
+
+(method_def
+  name: (identifier) @name
+  (#set! "kind" "Method")) @symbol
+
+(const_assign
+  lhs: (constant) @name
+  (#set! "kind" "Constant")) @symbol

--- a/queries/nvim/aerial.scm
+++ b/queries/nvim/aerial.scm
@@ -21,3 +21,19 @@
 (const_assign
   lhs: (constant) @name
   (#set! "kind" "Constant")) @symbol
+
+(alias
+  name: (constant) @name
+  (#set! "kind" "Class")) @symbol
+
+(lib_def
+  name: (constant) @name
+  (#set! "kind" "Module")) @symbol
+
+(fun_def
+  name: (identifier) @name
+  (#set! "kind" "Function")) @symbol
+
+(annotation_def
+  name: (constant) @name
+  (#set! "kind" "Class")) @symbol


### PR DESCRIPTION
A plugin to provide an outline view of current buffer. https://github.com/stevearc/aerial.nvim

![image](https://github.com/user-attachments/assets/9e3db196-a88a-42db-90ac-11e8630c65bb)

I saw some queries in their repo for constants, however they aren't visible with the default aerial configuration, but I added them anyway.