### PR TITLE
Move ` \s:\s` token to external scanner

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -2873,7 +2873,7 @@ module.exports = grammar({
       return seq(
         alias($._regular_rescue_keyword, 'rescue'),
         optional(choice(
-          seq(rescue_variable, ': ', rescue_type),
+          seq(rescue_variable, /:\s/, rescue_type),
           rescue_variable,
           rescue_type,
         )),

--- a/grammar.js
+++ b/grammar.js
@@ -101,6 +101,13 @@ module.exports = grammar({
 
     $.unquoted_symbol,
 
+    // Represents the /\s:\s/ token that comes before param and return types.
+    // The main reason for moving this token to the external scanner is a
+    // workaround for https://github.com/tree-sitter/tree-sitter/issues/4091.
+    // A literal like `/\s:\s/` or `' : '` in the grammar causes problems with
+    // other leading whitespace.
+    $._type_field_colon,
+
     $._string_literal_start,
     $._delimited_string_contents,
     $._string_literal_end,
@@ -1168,7 +1175,7 @@ module.exports = grammar({
       const params = seq(
         '(', optional(field('params', alias($.fun_param_list, $.param_list))), ')',
       )
-      const return_type = field('type', seq(/[ \t]:\s/, $._bare_type))
+      const return_type = field('type', seq($._type_field_separator, $._bare_type))
 
       return seq(
         prec.right(seq(
@@ -1199,7 +1206,7 @@ module.exports = grammar({
         )),
         ')',
       )
-      const return_type = field('type', seq(/[ \t]:\s/, $._bare_type))
+      const return_type = field('type', seq($._type_field_separator, $._bare_type))
 
       return seq(
         'fun',
@@ -1232,13 +1239,19 @@ module.exports = grammar({
 
     fun_param: $ => {
       const name = field('name', choice($.identifier, $.constant))
-      const type = field('type', seq(/[ \t]:\s/, $._bare_type))
+      const type = field('type', seq($._type_field_separator, $._bare_type))
 
       return seq(
         name,
         type,
       )
     },
+
+    // A separator between a parameter and its type, or a method signature and its return type.
+    // Must have whitespace on both sides, e.g.
+    //   param : Type
+    //        ^^^
+    _type_field_separator: $ => alias($._type_field_colon, ':'),
 
     type_def: $ => seq(
       'type',
@@ -1282,7 +1295,7 @@ module.exports = grammar({
 
       return seq(
         field('name', names),
-        /[ \t]:\s/,
+        $._type_field_separator,
         field('type', $._bare_type),
       )
     },
@@ -1321,7 +1334,7 @@ module.exports = grammar({
 
       return seq(
         field('name', names),
-        /[ \t]:\s/,
+        $._type_field_separator,
         field('type', $._bare_type),
       )
     },
@@ -1329,7 +1342,7 @@ module.exports = grammar({
     global_var: $ => {
       const name = field('name', seq('$', $.identifier))
       const real_name = field('real_name', choice($.identifier, $.constant))
-      const return_type = field('type', seq(/[ \t]:\s/, $._bare_type))
+      const return_type = field('type', seq($._type_field_separator, $._bare_type))
 
       return seq(
         name,
@@ -1353,7 +1366,7 @@ module.exports = grammar({
         alias('`', $.operator),
       ))
       const params = seq('(', field('params', optional($.param_list)), ')')
-      const return_type = field('type', seq(/[ \t]:\s/, $._bare_type))
+      const return_type = field('type', seq($._type_field_separator, $._bare_type))
       const forall = field('forall', $.forall)
 
       return prec.right(seq(
@@ -1486,7 +1499,7 @@ module.exports = grammar({
       const name = field('name', choice(
         $.identifier, $.instance_var, $.class_var, $.macro_var,
       ))
-      const type = field('type', seq(/[ \t]:\s/, $._bare_type))
+      const type = field('type', seq($._type_field_separator, $._bare_type))
       const default_value = field('default', seq('=', $._expression))
 
       return seq(
@@ -1502,7 +1515,7 @@ module.exports = grammar({
       const name = field('name', choice(
         $.identifier, $.instance_var, $.class_var, $.macro_var,
       ))
-      const type = field('type', seq(/[ \t]:\s/, $._bare_type))
+      const type = field('type', seq($._type_field_separator, $._bare_type))
 
       return seq(
         repeat($.annotation),
@@ -1516,7 +1529,7 @@ module.exports = grammar({
       const name = field('name', choice(
         $.identifier, $.instance_var, $.class_var, $.macro_var,
       ))
-      const type = field('type', seq(/[ \t]:\s/, $._bare_type))
+      const type = field('type', seq($._type_field_separator, $._bare_type))
 
       return seq(
         repeat($.annotation),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -13682,8 +13682,8 @@
                       }
                     },
                     {
-                      "type": "STRING",
-                      "value": ": "
+                      "type": "PATTERN",
+                      "value": ":\\s"
                     },
                     {
                       "type": "FIELD",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4932,8 +4932,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "PATTERN",
-                          "value": "[ \\t]:\\s"
+                          "type": "SYMBOL",
+                          "name": "_type_field_separator"
                         },
                         {
                           "type": "SYMBOL",
@@ -5105,8 +5105,8 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "PATTERN",
-                    "value": "[ \\t]:\\s"
+                    "type": "SYMBOL",
+                    "name": "_type_field_separator"
                   },
                   {
                     "type": "SYMBOL",
@@ -5275,8 +5275,8 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "PATTERN",
-                "value": "[ \\t]:\\s"
+                "type": "SYMBOL",
+                "name": "_type_field_separator"
               },
               {
                 "type": "SYMBOL",
@@ -5286,6 +5286,15 @@
           }
         }
       ]
+    },
+    "_type_field_separator": {
+      "type": "ALIAS",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_type_field_colon"
+      },
+      "named": false,
+      "value": ":"
     },
     "type_def": {
       "type": "SEQ",
@@ -5455,8 +5464,8 @@
           }
         },
         {
-          "type": "PATTERN",
-          "value": "[ \\t]:\\s"
+          "type": "SYMBOL",
+          "name": "_type_field_separator"
         },
         {
           "type": "FIELD",
@@ -5603,8 +5612,8 @@
           }
         },
         {
-          "type": "PATTERN",
-          "value": "[ \\t]:\\s"
+          "type": "SYMBOL",
+          "name": "_type_field_separator"
         },
         {
           "type": "FIELD",
@@ -5677,8 +5686,8 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "PATTERN",
-                "value": "[ \\t]:\\s"
+                "type": "SYMBOL",
+                "name": "_type_field_separator"
               },
               {
                 "type": "SYMBOL",
@@ -5958,8 +5967,8 @@
                   "type": "SEQ",
                   "members": [
                     {
-                      "type": "PATTERN",
-                      "value": "[ \\t]:\\s"
+                      "type": "SYMBOL",
+                      "name": "_type_field_separator"
                     },
                     {
                       "type": "SYMBOL",
@@ -6533,8 +6542,8 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "PATTERN",
-                    "value": "[ \\t]:\\s"
+                    "type": "SYMBOL",
+                    "name": "_type_field_separator"
                   },
                   {
                     "type": "SYMBOL",
@@ -6632,8 +6641,8 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "PATTERN",
-                    "value": "[ \\t]:\\s"
+                    "type": "SYMBOL",
+                    "name": "_type_field_separator"
                   },
                   {
                     "type": "SYMBOL",
@@ -6698,8 +6707,8 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "PATTERN",
-                    "value": "[ \\t]:\\s"
+                    "type": "SYMBOL",
+                    "name": "_type_field_separator"
                   },
                   {
                     "type": "SYMBOL",
@@ -15506,6 +15515,10 @@
     {
       "type": "SYMBOL",
       "name": "unquoted_symbol"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_type_field_colon"
     },
     {
       "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -20829,10 +20829,6 @@
     "named": false
   },
   {
-    "type": ": ",
-    "named": false
-  },
-  {
     "type": ":\"",
     "named": false
   },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -68,6 +68,10 @@
             "named": false
           },
           {
+            "type": ":",
+            "named": false
+          },
+          {
             "type": "class_type",
             "named": true
           },
@@ -5604,6 +5608,10 @@
             "named": false
           },
           {
+            "type": ":",
+            "named": false
+          },
+          {
             "type": "class_type",
             "named": true
           },
@@ -6682,6 +6690,10 @@
             "named": false
           },
           {
+            "type": ":",
+            "named": false
+          },
+          {
             "type": "class_type",
             "named": true
           },
@@ -6773,6 +6785,10 @@
           },
           {
             "type": ")",
+            "named": false
+          },
+          {
+            "type": ":",
             "named": false
           },
           {
@@ -6933,6 +6949,10 @@
           },
           {
             "type": ")",
+            "named": false
+          },
+          {
+            "type": ":",
             "named": false
           },
           {
@@ -10865,6 +10885,10 @@
           },
           {
             "type": ")",
+            "named": false
+          },
+          {
+            "type": ":",
             "named": false
           },
           {
@@ -15311,6 +15335,10 @@
             "named": false
           },
           {
+            "type": ":",
+            "named": false
+          },
+          {
             "type": "class_type",
             "named": true
           },
@@ -17206,6 +17234,10 @@
           },
           {
             "type": ")",
+            "named": false
+          },
+          {
+            "type": ":",
             "named": false
           },
           {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -71,6 +71,8 @@ enum Token {
 
     UNQUOTED_SYMBOL,
 
+    TYPE_FIELD_COLON,
+
     STRING_LITERAL_START,
     DELIMITED_STRING_CONTENTS,
     STRING_LITERAL_END,
@@ -368,6 +370,7 @@ static bool scan_whitespace(State *state, TSLexer *lexer, const bool *valid_symb
                     lex_advance(lexer);
                     lexer->mark_end(lexer);
                     crossed_newline = true;
+                    state->has_leading_whitespace = true;
                 } else {
                     lex_skip(state, lexer);
                 }
@@ -394,6 +397,18 @@ static bool scan_whitespace(State *state, TSLexer *lexer, const bool *valid_symb
                         }
                     } else if (lexer->lookahead == '#') {
                         // Comments don't interrupt line continuations
+                    } else if (lexer->lookahead == ':' && valid_symbols[TYPE_FIELD_COLON]) {
+                        // Check for a type field separator that comes after a newline, e.g.
+                        //   ( params )
+                        //   : ReturnType
+                        lex_advance(lexer);
+                        if (iswspace(lexer->lookahead)) {
+                            lex_advance(lexer);
+                            lexer->mark_end(lexer);
+                            lexer->result_symbol = TYPE_FIELD_COLON;
+                        } else {
+                            lexer->result_symbol = LINE_BREAK;
+                        }
                     } else {
                         lexer->result_symbol = LINE_BREAK;
                     }
@@ -2571,10 +2586,20 @@ static bool inner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols)
             break;
 
         case ':':
-            if (valid_symbols[UNQUOTED_SYMBOL]) {
+            if (valid_symbols[UNQUOTED_SYMBOL] || valid_symbols[TYPE_FIELD_COLON]) {
                 lex_advance(lexer);
 
                 int32_t lookahead = lexer->lookahead;
+
+                if (state->has_leading_whitespace && iswspace(lookahead) && valid_symbols[TYPE_FIELD_COLON]) {
+                    lex_advance(lexer);
+                    lexer->result_symbol = TYPE_FIELD_COLON;
+                    return true;
+                }
+
+                if (!valid_symbols[UNQUOTED_SYMBOL]) {
+                    return false;
+                }
 
                 if (('A' <= lookahead && lookahead <= 'Z')
                     || ('a' <= lookahead && lookahead <= 'z')
@@ -2861,6 +2886,7 @@ bool tree_sitter_crystal_external_scanner_scan(void *payload, TSLexer *lexer, co
     LOG_SYMBOL(MODIFIER_ENSURE_KEYWORD);
     LOG_SYMBOL(MODULO_OPERATOR);
     LOG_SYMBOL(UNQUOTED_SYMBOL);
+    LOG_SYMBOL(TYPE_FIELD_COLON);
     LOG_SYMBOL(STRING_LITERAL_START);
     LOG_SYMBOL(DELIMITED_STRING_CONTENTS);
     LOG_SYMBOL(STRING_LITERAL_END);

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -924,6 +924,13 @@ rescue err : FooError | BarError
 else
 :foo
 end
+
+begin
+rescue e :
+RuntimeError
+rescue e:
+RuntimeError2
+end
 --------------------------------------------------------------------------------
 
 (expressions
@@ -969,7 +976,14 @@ end
         (constant)))
     else: (else
       body: (expressions
-        (symbol)))))
+        (symbol))))
+  (begin
+    rescue: (rescue
+      variable: (identifier)
+      type: (constant))
+    rescue: (rescue
+      variable: (identifier)
+      type: (constant))))
 
 ================================================================================
 begin blocks with ensure

--- a/test/corpus/todo.txt
+++ b/test/corpus/todo.txt
@@ -19,6 +19,15 @@ ReturnType
   puts "hello"
 end
 
+lib Foo
+fun
+bar
+(
+)
+:
+Type
+end
+
 ---
 
 (expressions


### PR DESCRIPTION
After working around https://github.com/tree-sitter/tree-sitter/issues/4091, this means the `tree-sitter fuzz` command is useful now!