### PR TITLE
Fix named tuple assertion failure

### DIFF
--- a/test/corpus/errors.txt
+++ b/test/corpus/errors.txt
@@ -561,3 +561,19 @@ end
         (argument_list
           (string)))))
   (ERROR))
+
+================================================================================
+can't use a named tuple for hash-like syntax
+================================================================================
+Foo { a: 1 }
+--------------------------------------------------------------------------------
+
+(expressions
+  (array_like
+    name: (constant)
+    values: (tuple
+      (call
+        method: (identifier)
+        (ERROR)
+        arguments: (argument_list
+          (integer))))))


### PR DESCRIPTION
Address an assertion failure triggered by
```
Foo { a: 1 }
```