### PR TITLE
Use `escape_sequence` for all escape types

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -706,7 +706,7 @@ module.exports = grammar({
       '\'',
       choice(
         alias(token.immediate(prec(1, /[^\\]/)), $.literal_content),
-        $.char_escape_sequence,
+        alias($.char_escape_sequence, $.escape_sequence),
       ),
       token.immediate('\''),
     ),
@@ -731,8 +731,8 @@ module.exports = grammar({
     _string_literal_content: $ => repeat1(choice(
       $._line_continuation,
       alias($._delimited_string_contents, $.literal_content),
-      $.string_escape_sequence,
-      $.ignored_backslash,
+      alias($.string_escape_sequence, $.escape_sequence),
+      alias($.ignored_backslash, $.escape_sequence),
       $.interpolation,
     )),
 
@@ -779,8 +779,8 @@ module.exports = grammar({
     _string_percent_literal_content: $ => repeat1(choice(
       alias($._delimited_string_contents, $.literal_content),
       $.interpolation,
-      $.string_escape_sequence,
-      $.ignored_backslash,
+      alias($.string_escape_sequence, $.escape_sequence),
+      alias($.ignored_backslash, $.escape_sequence),
     )),
 
     string_array_percent_literal: $ => seq(
@@ -803,7 +803,7 @@ module.exports = grammar({
       $._delimited_array_element_start,
       repeat(choice(
         alias($._delimited_string_contents, $.literal_content),
-        alias($.percent_array_escape_sequence, $.ignored_backslash),
+        alias($.percent_array_escape_sequence, $.escape_sequence),
       )),
       $._delimited_array_element_end,
     ),
@@ -818,8 +818,8 @@ module.exports = grammar({
       repeat(choice(
         alias($.heredoc_content, $.literal_content),
         $.interpolation,
-        seq(/\s*/, $.string_escape_sequence),
-        seq(/\s*/, $.ignored_backslash),
+        seq(/\s*/, alias($.string_escape_sequence, $.escape_sequence)),
+        seq(/\s*/, alias($.ignored_backslash, $.escape_sequence)),
         $._line_continuation,
       )),
       $.heredoc_end,
@@ -860,8 +860,8 @@ module.exports = grammar({
         seq(
           repeat(choice(
             symbol_content,
-            $.string_escape_sequence,
-            $.ignored_backslash,
+            alias($.string_escape_sequence, $.escape_sequence),
+            alias($.ignored_backslash, $.escape_sequence),
           )),
           token.immediate('"'),
         ),

--- a/queries/nvim/highlights.scm
+++ b/queries/nvim/highlights.scm
@@ -76,6 +76,9 @@
 (string
   (literal_content) @string)
 
+(string
+  (escape_sequence) @string.escape)
+
 (symbol
   [
    ":"
@@ -86,11 +89,17 @@
 (symbol
   (literal_content) @string.special.symbol)
 
+(symbol
+  (escape_sequence) @character)
+
 (command
   "`" @string.special)
 
 (command
   (literal_content) @string.special)
+
+(command
+  (escape_sequence) @character)
 
 (regex
   "/" @punctuation.bracket)
@@ -103,18 +112,22 @@
 (heredoc_body
   (literal_content) @string)
 
+(heredoc_body
+  (escape_sequence) @string.escape)
+
 [
   (heredoc_start)
   (heredoc_end)
 ] @label
-
-(string_escape_sequence) @string.escape
 
 (char
   "'" @character)
 
 (char
   (literal_content) @character)
+
+(char
+  (escape_sequence) @string.escape)
 
 (integer) @number
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2316,8 +2316,13 @@
               "value": "literal_content"
             },
             {
-              "type": "SYMBOL",
-              "name": "char_escape_sequence"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "char_escape_sequence"
+              },
+              "named": true,
+              "value": "escape_sequence"
             }
           ]
         },
@@ -2467,12 +2472,22 @@
             "value": "literal_content"
           },
           {
-            "type": "SYMBOL",
-            "name": "string_escape_sequence"
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "string_escape_sequence"
+            },
+            "named": true,
+            "value": "escape_sequence"
           },
           {
-            "type": "SYMBOL",
-            "name": "ignored_backslash"
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ignored_backslash"
+            },
+            "named": true,
+            "value": "escape_sequence"
           },
           {
             "type": "SYMBOL",
@@ -2721,12 +2736,22 @@
             "name": "interpolation"
           },
           {
-            "type": "SYMBOL",
-            "name": "string_escape_sequence"
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "string_escape_sequence"
+            },
+            "named": true,
+            "value": "escape_sequence"
           },
           {
-            "type": "SYMBOL",
-            "name": "ignored_backslash"
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "ignored_backslash"
+            },
+            "named": true,
+            "value": "escape_sequence"
           }
         ]
       }
@@ -2829,7 +2854,7 @@
                   "name": "percent_array_escape_sequence"
                 },
                 "named": true,
-                "value": "ignored_backslash"
+                "value": "escape_sequence"
               }
             ]
           }
@@ -2880,8 +2905,13 @@
                     "value": "\\s*"
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "string_escape_sequence"
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "string_escape_sequence"
+                    },
+                    "named": true,
+                    "value": "escape_sequence"
                   }
                 ]
               },
@@ -2893,8 +2923,13 @@
                     "value": "\\s*"
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "ignored_backslash"
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "ignored_backslash"
+                    },
+                    "named": true,
+                    "value": "escape_sequence"
                   }
                 ]
               },
@@ -3117,12 +3152,22 @@
                     "value": "literal_content"
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "string_escape_sequence"
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "string_escape_sequence"
+                    },
+                    "named": true,
+                    "value": "escape_sequence"
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "ignored_backslash"
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "ignored_backslash"
+                    },
+                    "named": true,
+                    "value": "escape_sequence"
                   }
                 ]
               }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3971,7 +3971,7 @@
       "required": true,
       "types": [
         {
-          "type": "char_escape_sequence",
+          "type": "escape_sequence",
           "named": true
         },
         {
@@ -4115,7 +4115,7 @@
       "required": false,
       "types": [
         {
-          "type": "ignored_backslash",
+          "type": "escape_sequence",
           "named": true
         },
         {
@@ -4124,10 +4124,6 @@
         },
         {
           "type": "literal_content",
-          "named": true
-        },
-        {
-          "type": "string_escape_sequence",
           "named": true
         }
       ]
@@ -7497,11 +7493,11 @@
       "required": true,
       "types": [
         {
-          "type": "heredoc_end",
+          "type": "escape_sequence",
           "named": true
         },
         {
-          "type": "ignored_backslash",
+          "type": "heredoc_end",
           "named": true
         },
         {
@@ -7510,10 +7506,6 @@
         },
         {
           "type": "literal_content",
-          "named": true
-        },
-        {
-          "type": "string_escape_sequence",
           "named": true
         }
       ]
@@ -8952,7 +8944,7 @@
       "required": false,
       "types": [
         {
-          "type": "ignored_backslash",
+          "type": "escape_sequence",
           "named": true
         },
         {
@@ -8961,10 +8953,6 @@
         },
         {
           "type": "literal_content",
-          "named": true
-        },
-        {
-          "type": "string_escape_sequence",
           "named": true
         }
       ]
@@ -17498,7 +17486,7 @@
       "required": false,
       "types": [
         {
-          "type": "ignored_backslash",
+          "type": "escape_sequence",
           "named": true
         },
         {
@@ -17507,10 +17495,6 @@
         },
         {
           "type": "literal_content",
-          "named": true
-        },
-        {
-          "type": "string_escape_sequence",
           "named": true
         }
       ]
@@ -17579,15 +17563,11 @@
       "required": false,
       "types": [
         {
-          "type": "ignored_backslash",
+          "type": "escape_sequence",
           "named": true
         },
         {
           "type": "literal_content",
-          "named": true
-        },
-        {
-          "type": "string_escape_sequence",
           "named": true
         }
       ]
@@ -20998,10 +20978,6 @@
     "named": false
   },
   {
-    "type": "char_escape_sequence",
-    "named": true
-  },
-  {
     "type": "class",
     "named": false
   },
@@ -21042,6 +21018,10 @@
     "named": false
   },
   {
+    "type": "escape_sequence",
+    "named": true
+  },
+  {
     "type": "extend",
     "named": false
   },
@@ -21076,10 +21056,6 @@
   {
     "type": "if",
     "named": false
-  },
-  {
-    "type": "ignored_backslash",
-    "named": true
   },
   {
     "type": "in",
@@ -21171,10 +21147,6 @@
   },
   {
     "type": "special_variable",
-    "named": true
-  },
-  {
-    "type": "string_escape_sequence",
     "named": true
   },
   {

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -601,7 +601,7 @@ bar 1, c: + 2,
       (named_expr
         name: (string
           (literal_content)
-          (string_escape_sequence)
+          (escape_sequence)
           (literal_content))
         (char
           (literal_content)))

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -253,39 +253,39 @@ chars
   (char
     (literal_content))
   (char
-    (char_escape_sequence))
+    (escape_sequence))
   (char
-    (char_escape_sequence))
+    (escape_sequence))
   (char
-    (char_escape_sequence))
+    (escape_sequence))
   (char
-    (char_escape_sequence))
+    (escape_sequence))
   (char
-    (char_escape_sequence))
+    (escape_sequence))
   (char
-    (char_escape_sequence))
+    (escape_sequence))
   (char
-    (char_escape_sequence))
+    (escape_sequence))
   (char
-    (char_escape_sequence))
+    (escape_sequence))
   (char
-    (char_escape_sequence))
+    (escape_sequence))
   (char
-    (char_escape_sequence))
+    (escape_sequence))
   (char
-    (char_escape_sequence))
+    (escape_sequence))
   (char
-    (char_escape_sequence))
+    (escape_sequence))
   (char
-    (char_escape_sequence))
+    (escape_sequence))
   (char
-    (char_escape_sequence))
+    (escape_sequence))
   (char
-    (char_escape_sequence))
+    (escape_sequence))
   (char
-    (char_escape_sequence))
+    (escape_sequence))
   (char
-    (char_escape_sequence)))
+    (escape_sequence)))
 
 ================================================================================
 strings
@@ -340,49 +340,49 @@ strings
     (literal_content))
   (string)
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
-    (ignored_backslash))
+    (escape_sequence))
   (string
-    (ignored_backslash))
+    (escape_sequence))
   (string
-    (ignored_backslash))
+    (escape_sequence))
   (string
-    (ignored_backslash)))
+    (escape_sequence)))
 
 ================================================================================
 string interpolation
@@ -404,10 +404,10 @@ string interpolation
   (string
     (literal_content))
   (string
-    (ignored_backslash)
+    (escape_sequence)
     (literal_content))
   (string
-    (ignored_backslash)
+    (escape_sequence)
     (literal_content))
   (string
     (interpolation
@@ -602,9 +602,9 @@ c
     rhs: (heredoc_start))
   (heredoc_body
     (literal_content)
-    (string_escape_sequence)
+    (escape_sequence)
     (literal_content)
-    (ignored_backslash)
+    (escape_sequence)
     (literal_content)
     (heredoc_end))
   (heredoc_body
@@ -841,9 +841,9 @@ p <<-TEXT
       (heredoc_start)))
   (heredoc_body
     (literal_content)
-    (string_escape_sequence)
+    (escape_sequence)
     (literal_content)
-    (ignored_backslash)
+    (escape_sequence)
     (literal_content)
     (heredoc_end)))
 
@@ -919,21 +919,21 @@ p% ()
   (string
     (literal_content))
   (string
-    (string_escape_sequence)
-    (ignored_backslash))
+    (escape_sequence)
+    (escape_sequence))
   (string
     (literal_content))
   (string
-    (ignored_backslash)
-    (string_escape_sequence))
+    (escape_sequence)
+    (escape_sequence))
   (string
     (literal_content))
   (string
     (literal_content))
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
-    (string_escape_sequence))
+    (escape_sequence))
   (string
     (literal_content)
     (interpolation
@@ -952,7 +952,7 @@ p% ()
     (literal_content))
   (string
     (literal_content)
-    (string_escape_sequence))
+    (escape_sequence))
   (string
     (literal_content)
     (interpolation
@@ -1034,43 +1034,43 @@ d |
   (array
     (string
       (literal_content)
-      (ignored_backslash)
+      (escape_sequence)
       (literal_content)))
   (array
     (string
       (literal_content)
-      (ignored_backslash)
+      (escape_sequence)
       (literal_content)))
   (array
     (string
       (literal_content)
-      (ignored_backslash))
+      (escape_sequence))
     (string
       (literal_content)))
   (array
     (string
       (literal_content))
     (string
-      (ignored_backslash)
-      (ignored_backslash)))
+      (escape_sequence)
+      (escape_sequence)))
   (array
     (string
       (literal_content)
-      (ignored_backslash)
+      (escape_sequence)
       (literal_content)))
   (array
     (string
-      (ignored_backslash)
+      (escape_sequence)
       (literal_content)))
   (array
     (string
       (literal_content)
-      (ignored_backslash)
+      (escape_sequence)
       (literal_content))
     (string
       (literal_content)
-      (ignored_backslash)
-      (ignored_backslash)
+      (escape_sequence)
+      (escape_sequence)
       (literal_content)))
   (array
     (string
@@ -1143,23 +1143,23 @@ d)
   (array
     (symbol
       (literal_content)
-      (ignored_backslash)
+      (escape_sequence)
       (literal_content)))
   (array
     (symbol
       (literal_content)
-      (ignored_backslash)
+      (escape_sequence)
       (literal_content)))
   (array
     (symbol
       (literal_content)
-      (ignored_backslash))
+      (escape_sequence))
     (symbol
       (literal_content)))
   (array
     (symbol
       (literal_content)
-      (ignored_backslash)
+      (escape_sequence)
       (literal_content))
     (symbol
       (literal_content)))
@@ -1167,25 +1167,25 @@ d)
     (symbol
       (literal_content))
     (symbol
-      (ignored_backslash)
-      (ignored_backslash)))
+      (escape_sequence)
+      (escape_sequence)))
   (array
     (symbol
       (literal_content)
-      (ignored_backslash)
+      (escape_sequence)
       (literal_content)))
   (array
     (symbol
-      (ignored_backslash)
+      (escape_sequence)
       (literal_content)))
   (array
     (symbol
       (literal_content)
-      (ignored_backslash)
+      (escape_sequence)
       (literal_content))
     (symbol
       (literal_content)
-      (ignored_backslash)
+      (escape_sequence)
       (literal_content)))
   (array
     (symbol
@@ -1262,7 +1262,7 @@ symbols
   (symbol
     (literal_content))
   (symbol
-    (ignored_backslash))
+    (escape_sequence))
   (symbol
     (literal_content))
   (conditional
@@ -1279,7 +1279,7 @@ symbols
       method: (identifier)
       arguments: (argument_list
         (symbol
-          (string_escape_sequence))))
+          (escape_sequence))))
     else: (symbol
       (literal_content))))
 
@@ -1436,21 +1436,21 @@ regexes
     method: (operator)
     arguments: (argument_list
       (string
-        (string_escape_sequence))))
+        (escape_sequence))))
   (call
     receiver: (regex
       (literal_content))
     method: (operator)
     arguments: (argument_list
       (string
-        (string_escape_sequence))))
+        (escape_sequence))))
   (call
     receiver: (regex
       (literal_content))
     method: (operator)
     arguments: (argument_list
       (string
-        (string_escape_sequence))))
+        (escape_sequence))))
   (regex
     (literal_content))
   (regex
@@ -1465,13 +1465,6 @@ regexes
     (literal_content))
   (regex
     (literal_content))
-  (call
-    receiver: (regex
-      (literal_content))
-    method: (operator)
-    arguments: (argument_list
-      (string
-        (literal_content))))
   (call
     receiver: (regex
       (literal_content))
@@ -1492,7 +1485,14 @@ regexes
     method: (operator)
     arguments: (argument_list
       (string
-        (string_escape_sequence))))
+        (literal_content))))
+  (call
+    receiver: (regex
+      (literal_content))
+    method: (operator)
+    arguments: (argument_list
+      (string
+        (escape_sequence))))
   (call
     receiver: (regex
       (literal_content))
@@ -1514,7 +1514,7 @@ regexes
     arguments: (argument_list
       (string
         (literal_content)
-        (string_escape_sequence))))
+        (escape_sequence))))
   (regex
     (literal_content)
     (interpolation
@@ -2157,22 +2157,22 @@ puts %x[echo \t[#{foo}]\]]
     (literal_content)
     (interpolation
       (identifier))
-    (string_escape_sequence)
+    (escape_sequence)
     (literal_content)
-    (ignored_backslash)
+    (escape_sequence)
     (literal_content)
-    (ignored_backslash))
+    (escape_sequence))
   (call
     method: (identifier)
     arguments: (argument_list
       (command
         (literal_content)
-        (string_escape_sequence)
+        (escape_sequence)
         (literal_content)
         (interpolation
           (identifier))
         (literal_content)
-        (ignored_backslash)))))
+        (escape_sequence)))))
 
 ================================================================================
 strings with backslash newlines

--- a/test/util.cr
+++ b/test/util.cr
@@ -48,9 +48,7 @@ class TreeSitterParseCleaner
   RENAMED_NODES = {
     "heredoc_start"                          => "string",
     "assign_call"                            => "call",
-    "string_escape_sequence"                 => "literal_content",
-    "char_escape_sequence"                   => "literal_content",
-    "ignored_backslash"                      => "literal_content",
+    "escape_sequence"                        => "literal_content",
     "macro_content\\s*\\(literal_content\\)" => "macro_content",
   }
 


### PR DESCRIPTION
The grammar has several types of escape sequence nodes:
- `char_escape_sequence` (only for chars)
- `string_escape_sequence` (everywhere else, not only for strings)
- `ignored_backslash` (used for "identity" escape sequences)

This PR renames all the above to `escape_sequence`. I've adjusted the highlighting as well, so `escape_sequence` is always highlighted in a color that contrasts with the surrounding content.

There are also line continuation backslashes, which are currently hidden nodes without any highlighting. These are unchanged. My intent here is that a line continuation looks different because it's not escaping a newline, it's obscuring a newline.

Highlighting improvements:
<details><summary>Before</summary>

![before screenshot](https://github.com/user-attachments/assets/8faae2ee-a22e-4be7-a742-6bde6834eed2)

</details> 

<details><summary>After</summary>

![after screenshot](https://github.com/user-attachments/assets/6d310274-3b0d-4482-8e5a-f10a9582745f)

</details> 
