### PR TITLE
Support modifier and control statements in interpolations

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -456,8 +456,22 @@ module.exports = grammar({
       $._enum_statement,
     ),
 
+    // A void value statement that may be used dynamically.
+    // In other words, `c = [b if a]` isn't valid syntax, but `c = "#{b if a}"` is okay.
+    _inline_statement: $ => choice(
+      $.modifier_if,
+      $.modifier_unless,
+      $.modifier_rescue,
+      $.modifier_ensure,
+
+      $.return,
+      $.next,
+      $.break,
+    ),
+
     _statement: $ => choice(
       $._expression,
+      $._inline_statement,
       $.const_assign,
       alias($.multi_assign, $.assign),
       $.annotation,
@@ -474,16 +488,8 @@ module.exports = grammar({
       alias($.top_level_fun_def, $.fun_def),
       $.visibility_modifier,
       $.require,
-      $.modifier_if,
-      $.modifier_unless,
-      $.modifier_rescue,
-      $.modifier_ensure,
       $.include,
       $.extend,
-
-      $.return,
-      $.next,
-      $.break,
     ),
 
     _lib_statement: $ => choice(
@@ -764,7 +770,7 @@ module.exports = grammar({
     },
 
     interpolation: $ => seq(
-      token(prec(1, '#{')), $._expression, '}',
+      token(prec(1, '#{')), choice($._expression, $._inline_statement), '}',
     ),
 
     string_percent_literal: $ => seq(
@@ -1950,7 +1956,7 @@ module.exports = grammar({
 
     macro_expression: $ => seq(
       '{{',
-      choice($.splat, $.double_splat, $._expression),
+      choice($.splat, $.double_splat, $._expression, $._inline_statement),
       '}}',
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -350,12 +350,49 @@
         }
       ]
     },
+    "_inline_statement": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "modifier_if"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "modifier_unless"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "modifier_rescue"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "modifier_ensure"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "return"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "next"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "break"
+        }
+      ]
+    },
     "_statement": {
       "type": "CHOICE",
       "members": [
         {
           "type": "SYMBOL",
           "name": "_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_inline_statement"
         },
         {
           "type": "SYMBOL",
@@ -433,39 +470,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "modifier_if"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "modifier_unless"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "modifier_rescue"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "modifier_ensure"
-        },
-        {
-          "type": "SYMBOL",
           "name": "include"
         },
         {
           "type": "SYMBOL",
           "name": "extend"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "return"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "next"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "break"
         }
       ]
     },
@@ -2676,8 +2685,17 @@
           }
         },
         {
-          "type": "SYMBOL",
-          "name": "_expression"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_inline_statement"
+            }
+          ]
         },
         {
           "type": "STRING",
@@ -8525,6 +8543,10 @@
             {
               "type": "SYMBOL",
               "name": "_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_inline_statement"
             }
           ]
         },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -8278,6 +8278,10 @@
           "named": true
         },
         {
+          "type": "break",
+          "named": true
+        },
+        {
           "type": "call",
           "named": true
         },
@@ -8402,7 +8406,27 @@
           "named": true
         },
         {
+          "type": "modifier_ensure",
+          "named": true
+        },
+        {
+          "type": "modifier_if",
+          "named": true
+        },
+        {
+          "type": "modifier_rescue",
+          "named": true
+        },
+        {
+          "type": "modifier_unless",
+          "named": true
+        },
+        {
           "type": "named_tuple",
+          "named": true
+        },
+        {
+          "type": "next",
           "named": true
         },
         {
@@ -8447,6 +8471,10 @@
         },
         {
           "type": "regex",
+          "named": true
+        },
+        {
+          "type": "return",
           "named": true
         },
         {
@@ -8967,6 +8995,10 @@
           "named": true
         },
         {
+          "type": "break",
+          "named": true
+        },
+        {
           "type": "call",
           "named": true
         },
@@ -9095,7 +9127,27 @@
           "named": true
         },
         {
+          "type": "modifier_ensure",
+          "named": true
+        },
+        {
+          "type": "modifier_if",
+          "named": true
+        },
+        {
+          "type": "modifier_rescue",
+          "named": true
+        },
+        {
+          "type": "modifier_unless",
+          "named": true
+        },
+        {
           "type": "named_tuple",
+          "named": true
+        },
+        {
+          "type": "next",
           "named": true
         },
         {
@@ -9140,6 +9192,10 @@
         },
         {
           "type": "regex",
+          "named": true
+        },
+        {
+          "type": "return",
           "named": true
         },
         {

--- a/test/corpus/macros.txt
+++ b/test/corpus/macros.txt
@@ -1105,3 +1105,44 @@ end
                     receiver: (identifier)
                     method: (identifier))))))))
       (macro_content))))
+
+===============================
+inline modifier statements in macro expression
+:language(crystal)
+===============================
+macro foo
+  {{ skip_file if compare_versions(Crystal::VERSION, "1.3.0") >= 0 }}
+
+  {% debug unless env("NO_DEBUG") %}
+end
+---
+
+(expressions
+  (macro_def
+    name: (identifier)
+    body: (expressions
+      (macro_content)
+      (macro_expression
+        (modifier_if
+          then: (identifier)
+          cond: (call
+            receiver: (call
+              method: (identifier)
+              arguments: (argument_list
+                (constant)
+                (string
+                  (literal_content))))
+            method: (operator)
+            arguments: (argument_list
+              (integer)))))
+      (macro_content)
+      (macro_statement
+        (expressions
+          (modifier_unless
+            then: (identifier)
+            cond: (call
+              method: (identifier)
+              arguments: (argument_list
+                (string
+                  (literal_content)))))))
+      (macro_content))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -1832,3 +1832,43 @@ end
           (call
             receiver: (constant)
             method: (identifier)))))))
+
+======================================
+inline statements inside interpolation
+:language(crystal)
+======================================
+"hello #{"world" if true}"
+s1 = "{#{a unless b}}"
+
+def foo
+  bar = "#{return 7}"
+end
+---
+
+(expressions
+  (string
+    (literal_content)
+    (interpolation
+      (modifier_if
+        then: (string
+          (literal_content))
+        cond: (true))))
+  (assign
+    lhs: (identifier)
+    rhs: (string
+      (literal_content)
+      (interpolation
+        (modifier_unless
+          then: (identifier)
+          cond: (identifier)))
+      (literal_content)))
+  (method_def
+    name: (identifier)
+    body: (expressions
+      (assign
+        lhs: (identifier)
+        rhs: (string
+          (interpolation
+            (return
+              (argument_list
+                (integer)))))))))

--- a/test/corpus/todo.txt
+++ b/test/corpus/todo.txt
@@ -219,23 +219,6 @@ filters1.try(&.pos[name]?)
               (identifier)))))
       (ERROR))))
 
-=========================
-trailing if inside interp
-=========================
-
-"hello #{"world" if true}"
-
----
-
-(expressions
-  (ERROR
-    (literal_content)
-    (string
-      (literal_content)
-      (ERROR
-        (identifier))
-      (literal_content))))
-
 ========================
 macro var as block param
 :error
@@ -374,15 +357,6 @@ keyword as named argument
 :error
 =========================
 pages.series(begin: 2, end: 2)
----
-
-(expressions)
-
-===============================
-modifier if in macro expression
-:error
-===============================
-{{ skip_file if compare_versions(Crystal::VERSION, "1.3.0") >= 0 }}
 ---
 
 (expressions)

--- a/test/crystal_parse_stdlib_fail.txt
+++ b/test/crystal_parse_stdlib_fail.txt
@@ -575,6 +575,7 @@ llvm/generic_value.cr
 llvm/global_collection.cr
 llvm/instruction_collection.cr
 llvm/jit_compiler.cr
+llvm/lib_llvm.cr
 llvm/lib_llvm/core.cr
 llvm/lib_llvm/transforms/pass_builder.cr
 llvm/lib_llvm_ext.cr

--- a/test/stdlib_coverage_expected_to_fail.txt
+++ b/test/stdlib_coverage_expected_to_fail.txt
@@ -8,5 +8,4 @@ compiler/crystal/syntax/ast.cr
 crystal/system/unix/file_descriptor.cr
 crystal/system/wasi/file_descriptor.cr
 io/memory.cr
-llvm/lib_llvm.cr
 range.cr


### PR DESCRIPTION
This adds support for `"#{a if b}"`, `{{a unless b}}`, etc.

Also supports syntax that no one should use but is technically allowed, like
```crystal
def foo
  a = "#{return 7}"
end
foo #=> 7
```

I don't love how much this blows up the state count, but it seems unavoidable.