### PR TITLE
Update to tree-sitter 0.25.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up tree-sitter
         uses: tree-sitter/setup-action/cli@v1
         with:
-          tree-sitter-ref: v0.25.9
+          tree-sitter-ref: v0.25.10
 
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
@@ -45,7 +45,7 @@ jobs:
       - name: Set up tree-sitter
         uses: tree-sitter/setup-action/cli@v1
         with:
-          tree-sitter-ref: v0.25.9
+          tree-sitter-ref: v0.25.10
 
       - name: Regenerate parser
         run: tree-sitter generate

--- a/.github/workflows/compile_check.yml
+++ b/.github/workflows/compile_check.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up tree-sitter
         uses: tree-sitter/setup-action/cli@v1
         with:
-          tree-sitter-ref: v0.25.9
+          tree-sitter-ref: v0.25.10
 
       - name: MSVC setup
         uses: ilammy/msvc-dev-cmd@v1

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,10 @@
         "eslint": "^9.16.0",
         "globals": "^15.13.0",
         "prebuildify": "^6.0.1",
-        "tree-sitter-cli": "^0.25.9"
+        "tree-sitter-cli": "^0.25.10"
       },
       "peerDependencies": {
-        "tree-sitter": "^0.22.1"
+        "tree-sitter": "^0.25.0"
       },
       "peerDependenciesMeta": {
         "tree_sitter": {
@@ -1323,11 +1323,10 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -1353,24 +1352,22 @@
       }
     },
     "node_modules/tree-sitter": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.1.tgz",
-      "integrity": "sha512-gRO+jk2ljxZlIn20QRskIvpLCMtzuLl5T0BY6L9uvPYD17uUrxlxWkvYCiVqED2q2q7CVtY52Uex4WcYo2FEXw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.25.0.tgz",
+      "integrity": "sha512-PGZZzFW63eElZJDe/b/R/LbsjDDYJa5UEjLZJB59RQsMX+fo0j54fqBPn1MGKav/QNa0JR0zBiVaikYDWCj5KQ==",
       "hasInstallScript": true,
-      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "node-addon-api": "^8.2.1",
-        "node-gyp-build": "^4.8.2"
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.25.9.tgz",
-      "integrity": "sha512-xcS2EJlNdwG529/JcYl5jV0ew/wY+HXvyNe8nkqhDCwQqxCH7odc9oLKxIWePQqmIKgieZ0YaGyieYKQI3MTKQ==",
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.25.10.tgz",
+      "integrity": "sha512-KoebQguKMCIghisEOdA372TIbrUl0kdnfZ9YQIBRAeOvNSKe85XbU4LuFW7hduRUwJj0rAG7pX5wo9sZhbBF1g==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "bin": {
         "tree-sitter": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -51,10 +51,10 @@
     "eslint": "^9.16.0",
     "globals": "^15.13.0",
     "prebuildify": "^6.0.1",
-    "tree-sitter-cli": "^0.25.9"
+    "tree-sitter-cli": "^0.25.10"
   },
   "peerDependencies": {
-    "tree-sitter": "^0.22.1"
+    "tree-sitter": "^0.25.0"
   },
   "peerDependenciesMeta": {
     "tree_sitter": {


### PR DESCRIPTION
This also silences the security warning about the `tar-fs` npm package